### PR TITLE
Suggested changes to fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,10 +34,10 @@
     "java": ">=17"
   },
   "suggests": {
-    "mythicmetals": "mythicmetals"
+    "mythicmetals": ">=0.15.2"
   },
   "recommends": {
-    "bettercombat": "bettercombat"
+    "bettercombat": ">=1.3.2"
   },
 
   "custom": {


### PR DESCRIPTION
When you want to make suggestions and recommendations to an end user, the second part of the suggestion or recommendation is a version number. In this case, it would appear that you are recommending any version of the mods, however, you would likely want to make sure that the versions that you are recommending are compatible with the version of the mod that is released. 

Therefore, in the case of Mythic Metals, it is suggested, here, that players make use of a version that is equal to or newer than the most stable version that Noaaan has released to date for 1.19, which is 0.15.2. However, since we were talking about making use of the tags that Noaaan had introduced in their development version, it might behoove you to suggest an even later version once that is released.

The same is the case for Better Combat. As Better Combat is recommended, for the best experience, you want to recommend the version that will reflect your mod the best. This is, most of the time, going to be the most recent version. For Better Combat, this would be 1.3.2, at this time. Therefore, I have put that the recommended version is equal to or newer than 1.3.2.

All of that being said, if you want to leave it wide open and suggest and recommend any version, that can be done in the following manner:

```
"suggests": {
    "mythicmetals": "*"
  },
  "recommends": {
    "bettercombat": "*"
  }
```
