### PR TITLE
Fixed Icewhisper tooltip ru_ru translation error

### DIFF
--- a/common/src/main/resources/assets/simplyswords/lang/ru_ru.json
+++ b/common/src/main/resources/assets/simplyswords/lang/ru_ru.json
@@ -558,7 +558,7 @@
   "item.simplyswords.icewhispersworditem.tooltip3": "урон и замедляет врагов в пределах %d блоков.",
   "item.simplyswords.icewhispersworditem.tooltip4": "Откажитесь от своей ледяной ауры и вместо этого вызовите",
   "item.simplyswords.icewhispersworditem.tooltip5": "снежную бурю в вашем местоположении, замедляя и нанося",
-  "item.simplyswords.icewhispersworditem.tooltip6": "увеличенный урон врагам в пределах % d блоков.",
+  "item.simplyswords.icewhispersworditem.tooltip6": "увеличенный урон врагам в пределах %d блоков.",
 
   "item.simplyswords.arcanethystsworditem.tooltip1": "Уникальный эффект: Тайное Нападение",
   "item.simplyswords.arcanethystsworditem.tooltip2": "Шанс при попадании получить тайный заряд.",


### PR DESCRIPTION
Fixing tooltip translation error in ru_ru translation for the Icewhisper.

**Russian locale**
![image](https://github.com/Sweenus/SimplySwords/assets/20380250/3a256dc5-1250-431f-98f2-543f686d6cb8)

**English locale**
![image](https://github.com/Sweenus/SimplySwords/assets/20380250/a2bf9705-209f-4b4e-90b8-040b40d7c382)
