### PR TITLE
[Forge & Fabric 1.20.1] JEED Compatibility

### DIFF
--- a/common/src/main/resources/assets/simplyswords/lang/en_us.json
+++ b/common/src/main/resources/assets/simplyswords/lang/en_us.json
@@ -541,7 +541,7 @@
   "effect.simplyswords.wildfire":                                                                                       "Wildfire",
   "effect.simplyswords.echo":                                                                                           "Echo",
   "effect.simplyswords.ward":                                                                                           "Ward",
-  "effect.simplyswords.immolation":                                                                                     "Immolation":
+  "effect.simplyswords.immolation":                                                                                     "Immolation",
   "effect.simplyswords.onslaught":                                                                                      "Onslaught",
   "effect.simplyswords.smouldering":                                                                                    "Smouldering",
   "effect.simplyswords.frenzy":                                                                                         "Frenzy",
@@ -975,7 +975,7 @@
   "item.simplyswords.uniquesworditem.runefused_power.imbued":                                                           "[ Runefused: Imbued ]",
   "item.simplyswords.imbuedsworditem.tooltip2":                                                                         "Chance on hit to deal additional",
   "item.simplyswords.imbuedsworditem.tooltip3":                                                                         "magic damage, scaling with durability.",
-  "item.simplyswords.pincushionsworditem.tooltip1":                                                                     "Runic Power: Pincushion":
+  "item.simplyswords.pincushionsworditem.tooltip1":                                                                     "Runic Power: Pincushion",
   "item.simplyswords.uniquesworditem.runefused_power.pincushion":                                                       "[ Runefused: Pincushion ]",
   "item.simplyswords.pincushionsworditem.tooltip2":                                                                     "Deal additional damage for each",
   "item.simplyswords.pincushionsworditem.tooltip3":                                                                     "arrow stuck in your body.",
@@ -983,7 +983,7 @@
   "item.simplyswords.wardsworditem.tooltip2":                                                                           "Sacrifice half your current HP to gain",
   "item.simplyswords.wardsworditem.tooltip3":                                                                           "pulsing absorption relative to your",
   "item.simplyswords.wardsworditem.tooltip4":                                                                           "remaining HP for 6 seconds.",
-  "item.simplyswords.immolationsworditem.tooltip1":                                                                     "Runic Power: Immolation":
+  "item.simplyswords.immolationsworditem.tooltip1":                                                                     "Runic Power: Immolation",
   "item.simplyswords.immolationsworditem.tooltip2":                                                                     "Gain an aura of immolation, periodically",
   "item.simplyswords.immolationsworditem.tooltip3":                                                                     "damaging you and nearby foes. Outgoing ",
   "item.simplyswords.immolationsworditem.tooltip4":                                                                     "damage scales with your current HP.",
@@ -1009,7 +1009,7 @@
 
   "item.simplyswords.uniquesworditem.netherfused_power.radiance":                                                       "[ Netherfused: Radiance ]",
   "item.simplyswords.uniquesworditem.netherfused_power.radiance.description":                                           "When hitting a target afflicted",
-  "item.simplyswords.uniquesworditem.netherfused_power.radiance.description2":                                          "with weakness, gain Immolation":
+  "item.simplyswords.uniquesworditem.netherfused_power.radiance.description2":                                          "with weakness, gain Immolation",
   "item.simplyswords.uniquesworditem.netherfused_power.radiance.description3":                                          "for a short duration.",
 
   "item.simplyswords.uniquesworditem.netherfused_power.onslaught":                                                      "[ Netherfused: Onslaught ]",
@@ -1361,8 +1361,8 @@
   "text.autoconfig.simplyswords_main.option.runic_effects.enableGreaterMomentum":                                       "Enable Greater Momentum",
   "text.autoconfig.simplyswords_main.option.runic_effects.enableImbued":                                                "Enable Imbued",
   "text.autoconfig.simplyswords_main.option.runic_effects.enableGreaterImbued":                                         "Enable Greater Imbued",
-  "text.autoconfig.simplyswords_main.option.runic_effects.enablePincushion":                                            "Enable Pincushion":
-  "text.autoconfig.simplyswords_main.option.runic_effects.enableGreaterPincushion":                                     "Enable Greater Pincushion":
+  "text.autoconfig.simplyswords_main.option.runic_effects.enablePincushion":                                            "Enable Pincushion",
+  "text.autoconfig.simplyswords_main.option.runic_effects.enableGreaterPincushion":                                     "Enable Greater Pincushion",
   "text.autoconfig.simplyswords_main.option.runic_effects.enableWard":                                                  "Enable Ward",
   "text.autoconfig.simplyswords_main.option.runic_effects.enableImmolate":                                              "Enable Immolate",
 
@@ -1440,20 +1440,20 @@
 
   "text.autoconfig.simplyswords_main.option.unique_effects.stealChance.@PrefixText" :                                   "§6[Soulstealer]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.stealChance":                                                "Steal chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.stealDuration":                                              "Steal duration":
-  "text.autoconfig.simplyswords_main.option.unique_effects.stealInvisDuration":                                         "Steal Invisible duration":
-  "text.autoconfig.simplyswords_main.option.unique_effects.stealBlindDuration":                                         "Steal Blind duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.stealDuration":                                              "Steal duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.stealInvisDuration":                                         "Steal Invisible duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.stealBlindDuration":                                         "Steal Blind duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.stealRadius":                                                "Steal radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.stealSpellScaling":                                          "Steal Spell Power DMG multi",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.soulMeldChance.@PrefixText" :                                "§6[Soulkeeper]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulMeldChance":                                             "Soulmeld chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.soulMeldDuration":                                           "Soulmeld duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.soulMeldDuration":                                           "Soulmeld duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulMeldRadius":                                             "Soulmeld Iradius",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.soulrendChance.@PrefixText" :                                "§6[Soulrender]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulrendChance":                                             "Soulrend chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.soulrendDuration":                                           "Soulrend duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.soulrendDuration":                                           "Soulrend duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulrendDamageMulti":                                        "Soulrend damage multiplier",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulrendHealMulti":                                          "Soulrend heal multiplier",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulrendRadius":                                             "Soulrend radius",
@@ -1462,13 +1462,13 @@
 
   "text.autoconfig.simplyswords_main.option.unique_effects.ferocityChance.@PrefixText" :                                "§6[Twisted Blade]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.ferocityChance":                                             "Ferocity chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.ferocityDuration":                                           "Ferocity duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.ferocityDuration":                                           "Ferocity duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.ferocityMaxStacks":                                          "Ferocity max stacks",
   "text.autoconfig.simplyswords_main.option.unique_effects.ferocityStrengthTier":                                       "Ferocity strength amplifier",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.emberIreChance.@PrefixText" :                                "§6[Emberblade]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.emberIreChance":                                             "Ember Ire chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.emberIreDuration":                                           "Ember Ire duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.emberIreDuration":                                           "Ember Ire duration",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.volcanicFuryChance.@PrefixText" :                            "§6[Hearthflame]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.volcanicFuryChance":                                         "Volcanic Fury chance",
@@ -1482,7 +1482,7 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.stormRadius":                                                "Storm radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.stormCooldown":                                                "Storm cooldown",
   "text.autoconfig.simplyswords_main.option.unique_effects.stormFrequency":                                                "Storm frequency",
-  "text.autoconfig.simplyswords_main.option.unique_effects.stormDuration":                                                "Storm duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.stormDuration":                                                "Storm duration",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.plagueChance.@PrefixText" :                                  "§6[Longsword of The Plague]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.plagueChance":                                               "Plague chance",
@@ -1496,16 +1496,16 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.soultetherRange.@PrefixText" :                               "§6[Soulpyre]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.soultetherRange":                                            "Soultether range",
   "text.autoconfig.simplyswords_main.option.unique_effects.soultetherRadius":                                           "Soultether radius",
-  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherDuration":                                         "Soultether duration":
-  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherIgniteDuration":                                   "Soultether Ignite duration":
-  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherResistanceDuration":                               "Soultether Resistance duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherDuration":                                         "Soultether duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherIgniteDuration":                                   "Soultether Ignite duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherResistanceDuration":                               "Soultether Resistance duration",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryCooldown.@PrefixText" :                             "§6[Frostfall]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryCooldown":                                          "Frost Fury cooldown",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryRadius":                                            "Frost Fury radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryDamage":                                            "Frost Fury damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryChance":                                            "Frost Fury chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryDuration":                                          "Frost Fury duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryDuration":                                          "Frost Fury duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFurySpellScaling":                                      "Frost Fury Spell Power DMG multi",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarCooldown.@PrefixText" :                            "§6[Molten Edge]§7",
@@ -1513,19 +1513,19 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarRadius":                                           "Molten Roar radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarKnockbackStrength":                                "Molten Roar Knockback strength",
   "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarChance":                                           "Molten Roar chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarDuration":                                         "Molten Roar duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarDuration":                                         "Molten Roar duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterRadius.@PrefixText" :                            "§6[Livyatan]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterRadius":                                         "Frost Shatter radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterDamage":                                         "Frost Shatter damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterChance":                                         "Frost Shatter chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterDuration":                                       "Frost Shatter duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterDuration":                                       "Frost Shatter duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterSpellScaling":                                   "Frost Shatter Spell Power DMG multi",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.permafrostRadius.@PrefixText" :                              "§6[Icewhisper]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.permafrostRadius":                                           "Permafrost radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.permafrostDamage":                                           "Permafrost damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.permafrostCooldown":                                         "Permafrost cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.permafrostDuration":                                         "Permafrost duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.permafrostDuration":                                         "Permafrost duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.permafrostSpellScaling":                                     "Permafrost Spell Power DMG multi",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultRadius.@PrefixText" :                           "§6[Arcanethyst]§7",
@@ -1533,7 +1533,7 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultDamage":                                        "Arcane Assault damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultCooldown":                                      "Arcane Assault cooldown",
   "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultChance":                                        "Arcane Assault chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultDuration":                                      "Arcane Assault duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultDuration":                                      "Arcane Assault duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultSpellScaling":                                  "Arcane Assault Spell Power DMG multi",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.thunderBlitzRadius.@PrefixText" :                            "§6[Thunderbrand]§7",
@@ -1552,7 +1552,7 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishAbsorptionCap":                                   "Soul Anguish absorption cap",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishDamage":                                          "Soul Anguish damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishCooldown":                                        "Soul Anguish cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishDuration":                                        "Soul Anguish duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishDuration":                                        "Soul Anguish duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishHeal":                                            "Soul Anguish heal",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishRange":                                           "Soul Anguish range",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishSpellScaling":                                    "Soul Anguish Spell Power DMG multi",
@@ -1568,7 +1568,7 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistCooldown":                                         "Shadowmist cooldown",
   "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistChance":                                           "Shadowmist chance",
   "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistDamageMulti":                                      "Shadowmist damage multiplier",
-  "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistBlindDuration":                                    "Shadowmist Blind duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistBlindDuration":                                    "Shadowmist Blind duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistRadius":                                           "Shadowmist radius",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.abyssalStandardCooldown.@PrefixText" :                       "§6[Abyssal Standard]§7",
@@ -1603,32 +1603,32 @@
 
   "text.autoconfig.simplyswords_main.option.unique_effects.hivemindCooldown.@PrefixText" :                              "§6[Hiveheart]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.hivemindCooldown":                                           "Hivemind cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.hivemindDuration":                                           "Hivemind duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.hivemindDuration":                                           "Hivemind duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.hivemindDamage":                                             "Hivemind damage modifier",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeCooldown.@PrefixText" :                        "§6[Star's Edge]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeCooldown":                                     "Celestial Surge cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeDuration":                                     "Celestial Surge duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeDuration":                                     "Celestial Surge duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeStacks":                                       "Celestial Surge Haste stacks",
   "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeDamageModifier":                               "Celestial Surge Damage modifier",
   "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeLifestealModifier":                            "Celestial Surge Lifesteal modifier",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.flickerFuryCooldown.@PrefixText" :                           "§6[Wickpiercer]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.flickerFuryCooldown":                                        "Flicker Fury cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.flickerFuryDuration":                                        "Flicker Fury duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.flickerFuryDuration":                                        "Flicker Fury duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.flickerFuryDamage":                                          "Flicker Fury damage modifier",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerDuration.@PrefixText" :                            "§6[Dreadtide]§7",
-  "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerDuration":                                         "Voidcaller duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerDuration":                                         "Voidcaller duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerStartingTickFrequency":                            "Voidcaller starting tick frequency",
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerDamageModifier":                                   "Voidcaller damage modifier",
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerCorruptionFrequency":                              "Voidcaller Corruption frequency",
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerCorruptionPerTick":                                "Voidcaller Corruption per tick",
-  "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerCorruptionDuration":                               "Voidcaller Corruption duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerCorruptionDuration":                               "Voidcaller Corruption duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerCorruptionMax":                                    "Voidcaller Corruption max",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.vortexDuration.@PrefixText" :                                "§6[Tempest]§7",
-  "text.autoconfig.simplyswords_main.option.unique_effects.vortexDuration":                                             "Vortex duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.vortexDuration":                                             "Vortex duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.vortexMaxSize":                                              "Vortex max size",
   "text.autoconfig.simplyswords_main.option.unique_effects.vortexMaxStacks":                                            "Vortex max stacks",
   "text.autoconfig.simplyswords_main.option.unique_effects.vortexSpellScaling":                                         "Vortex Spell Power DMG multi",
@@ -1648,7 +1648,7 @@
 
   "text.autoconfig.simplyswords_main.option.unique_effects.magistormCooldown.@PrefixText" :                           "§6[Magiscythe]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.magistormCooldown":                                                "Magiscythe cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.magistormDuration":                                                  "Magistorm duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.magistormDuration":                                                  "Magistorm duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.magistormRadius":                                                     "Magistorm radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.magistormDamage":                                                   "Magistorm damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.magistormRepairChance":                                          "Magistorm repair chance",
@@ -1675,7 +1675,7 @@
 
   "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftCooldown.@PrefixText" :                           "§6[Caelestis]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftCooldown":                                                "Astral Shift cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftDuration":                                                  "Astral Shift duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftDuration":                                                  "Astral Shift duration",
   "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftDamageModifier":                                      "Astral Shift damage modifier",
   "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftDamageMax":                                             "Astral Shift damage max",
   "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftChance":                                                    "Astral Shift avoidance chance",
@@ -1683,52 +1683,52 @@
 
   "text.autoconfig.simplyswords_main.option.runic_effects.swiftnessChance.@PrefixText" :                                "§b[Swiftness]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.swiftnessChance":                                             "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.swiftnessDuration":                                           "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.swiftnessDuration":                                           "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.slowChance.@PrefixText" :                                     "§b[Slow]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.slowChance":                                                  "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.slowDuration":                                                "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.slowDuration":                                                "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.poisonChance.@PrefixText" :                                   "§b[Poison]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.poisonChance":                                                "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.poisonDuration":                                              "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.poisonDuration":                                              "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.freezeChance.@PrefixText" :                                   "§b[Freeze]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.freezeChance":                                                "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.freezeDuration":                                              "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.freezeDuration":                                              "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.wildfireChance.@PrefixText" :                                 "§b[Wildfire]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.wildfireChance":                                              "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.wildfireDuration":                                            "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.wildfireDuration":                                            "Duration",
   "text.autoconfig.simplyswords_main.option.runic_effects.wildfireRadius":                                              "Radius",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.floatChance.@PrefixText" :                                    "§b[Float]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.floatChance":                                                 "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.floatDuration":                                               "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.floatDuration":                                               "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.zephyrChance.@PrefixText" :                                   "§b[Zephyr]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.zephyrChance":                                                "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.zephyrDuration":                                              "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.zephyrDuration":                                              "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.shieldingChance.@PrefixText" :                                "§b[Shielding]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.shieldingChance":                                             "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.shieldingDuration":                                           "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.shieldingDuration":                                           "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.stoneskinChance.@PrefixText" :                                "§b[Stoneskin]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.stoneskinChance":                                             "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.stoneskinDuration":                                           "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.stoneskinDuration":                                           "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.trailblazeChance.@PrefixText" :                               "§b[Trailblaze]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.trailblazeChance":                                            "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.trailblazeDuration":                                          "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.trailblazeDuration":                                          "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.weakenChance.@PrefixText" :                                   "§b[Weaken]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.weakenChance":                                                "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.weakenDuration":                                              "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.weakenDuration":                                              "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.unstableFrequency.@PrefixText" :                              "§b[Unstable]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.unstableFrequency":                                           "Frequency",
-  "text.autoconfig.simplyswords_main.option.runic_effects.unstableDuration":                                            "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.unstableDuration":                                            "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.activeDefenceFrequency.@PrefixText" :                         "§b[Active Defence]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.activeDefenceFrequency":                                      "Frequency",
@@ -1737,7 +1737,7 @@
   "text.autoconfig.simplyswords_main.option.runic_effects.frostWardFrequency.@PrefixText" :                             "§b[Frost Ward]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.frostWardFrequency":                                          "Frequency",
   "text.autoconfig.simplyswords_main.option.runic_effects.frostWardRadius":                                             "Radius",
-  "text.autoconfig.simplyswords_main.option.runic_effects.frostWardDuration":                                           "Duration":
+  "text.autoconfig.simplyswords_main.option.runic_effects.frostWardDuration":                                           "Duration",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.momentumCooldown.@PrefixText" :                               "§b[Momentum]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.momentumCooldown":                                            "Chance",

--- a/common/src/main/resources/assets/simplyswords/lang/en_us.json
+++ b/common/src/main/resources/assets/simplyswords/lang/en_us.json
@@ -541,7 +541,7 @@
   "effect.simplyswords.wildfire":                                                                                       "Wildfire",
   "effect.simplyswords.echo":                                                                                           "Echo",
   "effect.simplyswords.ward":                                                                                           "Ward",
-  "effect.simplyswords.immolation":                                                                                     "Immolation",
+  "effect.simplyswords.immolation":                                                                                     "Immolation":
   "effect.simplyswords.onslaught":                                                                                      "Onslaught",
   "effect.simplyswords.smouldering":                                                                                    "Smouldering",
   "effect.simplyswords.frenzy":                                                                                         "Frenzy",
@@ -975,7 +975,7 @@
   "item.simplyswords.uniquesworditem.runefused_power.imbued":                                                           "[ Runefused: Imbued ]",
   "item.simplyswords.imbuedsworditem.tooltip2":                                                                         "Chance on hit to deal additional",
   "item.simplyswords.imbuedsworditem.tooltip3":                                                                         "magic damage, scaling with durability.",
-  "item.simplyswords.pincushionsworditem.tooltip1":                                                                     "Runic Power: Pincushion",
+  "item.simplyswords.pincushionsworditem.tooltip1":                                                                     "Runic Power: Pincushion":
   "item.simplyswords.uniquesworditem.runefused_power.pincushion":                                                       "[ Runefused: Pincushion ]",
   "item.simplyswords.pincushionsworditem.tooltip2":                                                                     "Deal additional damage for each",
   "item.simplyswords.pincushionsworditem.tooltip3":                                                                     "arrow stuck in your body.",
@@ -983,7 +983,7 @@
   "item.simplyswords.wardsworditem.tooltip2":                                                                           "Sacrifice half your current HP to gain",
   "item.simplyswords.wardsworditem.tooltip3":                                                                           "pulsing absorption relative to your",
   "item.simplyswords.wardsworditem.tooltip4":                                                                           "remaining HP for 6 seconds.",
-  "item.simplyswords.immolationsworditem.tooltip1":                                                                     "Runic Power: Immolation",
+  "item.simplyswords.immolationsworditem.tooltip1":                                                                     "Runic Power: Immolation":
   "item.simplyswords.immolationsworditem.tooltip2":                                                                     "Gain an aura of immolation, periodically",
   "item.simplyswords.immolationsworditem.tooltip3":                                                                     "damaging you and nearby foes. Outgoing ",
   "item.simplyswords.immolationsworditem.tooltip4":                                                                     "damage scales with your current HP.",
@@ -1009,7 +1009,7 @@
 
   "item.simplyswords.uniquesworditem.netherfused_power.radiance":                                                       "[ Netherfused: Radiance ]",
   "item.simplyswords.uniquesworditem.netherfused_power.radiance.description":                                           "When hitting a target afflicted",
-  "item.simplyswords.uniquesworditem.netherfused_power.radiance.description2":                                          "with weakness, gain Immolation",
+  "item.simplyswords.uniquesworditem.netherfused_power.radiance.description2":                                          "with weakness, gain Immolation":
   "item.simplyswords.uniquesworditem.netherfused_power.radiance.description3":                                          "for a short duration.",
 
   "item.simplyswords.uniquesworditem.netherfused_power.onslaught":                                                      "[ Netherfused: Onslaught ]",
@@ -1094,6 +1094,58 @@
   "item.simplyswords.compat.mythicmetals.looting":                                                                      "Bonus Looting",
 
   "entity.simplyswords.battlestandard.name":                                                                            "%d's Battle Standard",
+
+  "effect.simplyswords.freeze.description":                                                                             "Freezes mobs in place. Mobs can even be frozen in mid-air.",
+  "effect.simplyswords.ward.description":                                                                               "The runic ward exchanges your health for an unbreakable vitalic armor based on your current state.",
+  "effect.simplyswords.immolation.description":                                                                         "A holy aura surrounds you, setting ablaze with holy flames foes who dare prey on you. These spectacular flames deal both fire and magic damage. The strength of these holy flames, however, depend on the vitality of the wielder.",
+  "effect.simplyswords.echo.description":                                                                               "Deals delayed magic damage. Higher levels deal more damage. \n\nThis effect is inflicted by the Fatal Flicker effect from Whisperwind.",
+  "effect.simplyswords.onslaught.description":                                                                          "The onslaught fills you with a desire to prevail, increasing your attack speed. However, your blade will weaken once the conflict subsides.",
+  "effect.simplyswords.battle_fatigue.description":                                                                     "Summoning the Battle Standard of cleansing has fatigued your ability to call for it once more.",
+  "effect.simplyswords.fatal_flicker.description":                                                                      "The power of Whisperwind shields you from severe harm and grants you the ability to dash through your enemies, inflicting them with Echo. The more enemies dashed through, the more Echo is amplified.",
+  "effect.simplyswords.smouldering.description":                                                                        "Emberlash claims you as its next victim, for being hit by the flaming dagger now deals more damage to you.",
+  "effect.simplyswords.frenzy.description":                                                                             "Wickpiercer instills fury into your mind, significantly increasing your attack speed by 80% and each thrust dealing damage twice.",
+  "effect.simplyswords.fire_vortex.description":                                                                        "The blazing fury of Tempest deals magic damage over time, decreases armor level, and significantly increases knockback resistance. Higher levels deal more damage and can amplify Elemental Vortex.",
+  "effect.simplyswords.frost_vortex.description":                                                                       "The shivering ice of Tempest deals magic damage over time, decreases speed, and significantly increases knockback resistance. Higher levels deal more damage and can amplify Elemental Vortex.",
+  "effect.simplyswords.elemental_vortex.description":                                                                   "A vortex of elemental energy wraps around the wielder of Tempest, dealing magic damage to enemies nearby. Higher levels increase the size and damage of the vortex.",
+  "effect.simplyswords.flameseed.description":                                                                          "From the raging flame of Flamewind, a seed is sown in the for of the wielder. As it germinates, magic damage is dealt over time; and once it matures, it will explode, dealing magic damage to all nearby entities—besides the wielder, of course. \n\nBut the rage does not subside there: For each enemy hit, an additional seed is sown, thus a chain reaction begins. For each explosion, the wielder will have their attack speed amplified.",
+  "effect.simplyswords.ribbonwrath.description":                                                                        "The sheer power of Ribboncleaver protects you from 15% of incoming damage in exchange for 5% less speed.",
+  "effect.simplyswords.ribboncleave.description":                                                                       "The wrath of Ribboncleaver pulses through your veins, increasing the damage of your next attack by 95% and providing extra knockback resistance until the foe has been struck.",
+  "effect.simplyswords.resilience.description":                                                                         "The power of the unique weapon shields you from your foe's next attack.",
+  "effect.simplyswords.spore_swarm.description":                                                                        "A swarm of toxic spores releases from Bramblethorn, inflicting great torture to any entity unfortunate enough to attack its wielder. \n\nSo long as there are enemies from which to protect the wielder, the swarm will not dissipate.",
+  "effect.simplyswords.pain.description":                                                                               "The vortex of Enigma inflicts tortrous pain, bringing your enemy to their knees.",
+  "effect.simplyswords.magistorm.description":                                                                          "A magical storm manifests above you through the power of Magiscythe, striking foes with magical bolts which deal magic damage. As more enemies are struck, the storm has a chance to amplify, increasing the frequency of strikes. \n\nSo long as there are enemies from which to protect the wielder, the storm will not dissipate. Unequipping Magiscythe will calm the wrath of the storm.",
+  "effect.simplyswords.magislam.description":                                                                           "Magispear grants you the magic to leap into the air and smite your foes below.",
+  "effect.simplyswords.astral_shift.description":                                                                       "Caelestis transports you briefly to the astral plane, shielding you from all forms of damage. Upon exiting the astral plane, a violent explosion will be unleashed upon foes nearby, dealing damage relative to the damage negated while invincible.",
+  "effect.simplyswords.wildfire.description":                                                                           "§4§o§lThis effect either is currently unused or does nothing.",
+  "effect.simplyswords.storm.description":                                                                              "§4§o§lThis effect either is currently unused or does nothing.",
+  "effect.simplyswords.voidcloak.description":                                                                          "§4§o§lThis effect either is currently unused or does nothing.",
+  "effect.simplyswords.void_assault.description":                                                                       "§4§o§lThis effect either is currently unused or does nothing.",
+  
+  "effect.simplyswords.freeze.desc":                                                                             "Freezes mobs in place. Mobs can even be frozen in mid-air.",
+  "effect.simplyswords.ward.desc":                                                                               "The runic ward exchanges your health for an unbreakable vitalic armor based on your current state.",
+  "effect.simplyswords.immolation.desc":                                                                         "A holy aura surrounds you, setting ablaze with holy flames foes who dare prey on you. These spectacular flames deal both fire and magic damage. The strength of these holy flames, however, depend on the vitality of the wielder.",
+  "effect.simplyswords.echo.desc":                                                                               "Deals delayed magic damage. Higher levels deal more damage. \n\nThis effect is inflicted by the Fatal Flicker effect from Whisperwind.",
+  "effect.simplyswords.onslaught.desc":                                                                          "The onslaught fills you with a desire to prevail, increasing your attack speed. However, your blade will weaken once the conflict subsides.",
+  "effect.simplyswords.battle_fatigue.desc":                                                                     "Summoning the Battle Standard of cleansing has fatigued your ability to call for it once more.",
+  "effect.simplyswords.fatal_flicker.desc":                                                                      "The power of Whisperwind shields you from severe harm and grants you the ability to dash through your enemies, inflicting them with Echo. The more enemies dashed through, the more Echo is amplified.",
+  "effect.simplyswords.smouldering.desc":                                                                        "Emberlash claims you as its next victim, for being hit by the flaming dagger now deals more damage to you.",
+  "effect.simplyswords.frenzy.desc":                                                                             "Wickpiercer instills fury into your mind, significantly increasing your attack speed by 80% and each thrust dealing damage twice.",
+  "effect.simplyswords.fire_vortex.desc":                                                                        "The blazing fury of Tempest deals magic damage over time, decreases armor level, and significantly increases knockback resistance. Higher levels deal more damage and can amplify Elemental Vortex.",
+  "effect.simplyswords.frost_vortex.desc":                                                                       "The shivering ice of Tempest deals magic damage over time, decreases speed, and significantly increases knockback resistance. Higher levels deal more damage and can amplify Elemental Vortex.",
+  "effect.simplyswords.elemental_vortex.desc":                                                                   "A vortex of elemental energy wraps around the wielder of Tempest, dealing magic damage to enemies nearby. Higher levels increase the size and damage of the vortex.",
+  "effect.simplyswords.flameseed.desc":                                                                          "From the raging flame of Flamewind, a seed is sown in the for of the wielder. As it germinates, magic damage is dealt over time; and once it matures, it will explode, dealing magic damage to all nearby entities—besides the wielder, of course. \n\nBut the rage does not subside there: For each enemy hit, an additional seed is sown, thus a chain reaction begins. For each explosion, the wielder will have their attack speed amplified.",
+  "effect.simplyswords.ribbonwrath.desc":                                                                        "The sheer power of Ribboncleaver protects you from 15% of incoming damage in exchange for 5% less speed.",
+  "effect.simplyswords.ribboncleave.desc":                                                                       "The wrath of Ribboncleaver pulses through your veins, increasing the damage of your next attack by 95% and providing extra knockback resistance until the foe has been struck.",
+  "effect.simplyswords.resilience.desc":                                                                         "The power of the unique weapon shields you from your foe's next attack.",
+  "effect.simplyswords.spore_swarm.desc":                                                                        "A swarm of toxic spores releases from Bramblethorn, inflicting great torture to any entity unfortunate enough to attack its wielder. \n\nSo long as there are enemies from which to protect the wielder, the swarm will not dissipate.",
+  "effect.simplyswords.pain.desc":                                                                               "The vortex of Enigma inflicts tortrous pain, bringing your enemy to their knees.",
+  "effect.simplyswords.magistorm.desc":                                                                          "A magical storm manifests above you through the power of Magiscythe, striking foes with magical bolts which deal magic damage. As more enemies are struck, the storm has a chance to amplify, increasing the frequency of strikes. \n\nSo long as there are enemies from which to protect the wielder, the storm will not dissipate. Unequipping Magiscythe will calm the wrath of the storm.",
+  "effect.simplyswords.magislam.desc":                                                                           "Magispear grants you the magic to leap into the air and smite your foes below.",
+  "effect.simplyswords.astral_shift.desc":                                                                       "Caelestis transports you briefly to the astral plane, shielding you from all forms of damage. Upon exiting the astral plane, a violent explosion will be unleashed upon foes nearby, dealing damage relative to the damage negated while invincible.",
+  "effect.simplyswords.wildfire.desc":                                                                           "§4§o§lThis effect either is currently unused or does nothing.",
+  "effect.simplyswords.storm.desc":                                                                              "§4§o§lThis effect either is currently unused or does nothing.",
+  "effect.simplyswords.voidcloak.desc":                                                                          "§4§o§lThis effect either is currently unused or does nothing.",
+  "effect.simplyswords.void_assault.desc":                                                                       "§4§o§lThis effect either is currently unused or does nothing.",
 
   "item.simplyswords.compat.scaleFire":                                                                                 "§7Ability scales with §6Fire§7 spell power",
   "item.simplyswords.compat.scaleFrost":                                                                                "§7Ability scales with §bFrost§7 spell power",
@@ -1309,8 +1361,8 @@
   "text.autoconfig.simplyswords_main.option.runic_effects.enableGreaterMomentum":                                       "Enable Greater Momentum",
   "text.autoconfig.simplyswords_main.option.runic_effects.enableImbued":                                                "Enable Imbued",
   "text.autoconfig.simplyswords_main.option.runic_effects.enableGreaterImbued":                                         "Enable Greater Imbued",
-  "text.autoconfig.simplyswords_main.option.runic_effects.enablePincushion":                                            "Enable Pincushion",
-  "text.autoconfig.simplyswords_main.option.runic_effects.enableGreaterPincushion":                                     "Enable Greater Pincushion",
+  "text.autoconfig.simplyswords_main.option.runic_effects.enablePincushion":                                            "Enable Pincushion":
+  "text.autoconfig.simplyswords_main.option.runic_effects.enableGreaterPincushion":                                     "Enable Greater Pincushion":
   "text.autoconfig.simplyswords_main.option.runic_effects.enableWard":                                                  "Enable Ward",
   "text.autoconfig.simplyswords_main.option.runic_effects.enableImmolate":                                              "Enable Immolate",
 
@@ -1388,20 +1440,20 @@
 
   "text.autoconfig.simplyswords_main.option.unique_effects.stealChance.@PrefixText" :                                   "§6[Soulstealer]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.stealChance":                                                "Steal chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.stealDuration":                                              "Steal duration",
-  "text.autoconfig.simplyswords_main.option.unique_effects.stealInvisDuration":                                         "Steal Invisible duration",
-  "text.autoconfig.simplyswords_main.option.unique_effects.stealBlindDuration":                                         "Steal Blind duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.stealDuration":                                              "Steal duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.stealInvisDuration":                                         "Steal Invisible duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.stealBlindDuration":                                         "Steal Blind duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.stealRadius":                                                "Steal radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.stealSpellScaling":                                          "Steal Spell Power DMG multi",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.soulMeldChance.@PrefixText" :                                "§6[Soulkeeper]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulMeldChance":                                             "Soulmeld chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.soulMeldDuration":                                           "Soulmeld duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.soulMeldDuration":                                           "Soulmeld duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.soulMeldRadius":                                             "Soulmeld Iradius",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.soulrendChance.@PrefixText" :                                "§6[Soulrender]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulrendChance":                                             "Soulrend chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.soulrendDuration":                                           "Soulrend duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.soulrendDuration":                                           "Soulrend duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.soulrendDamageMulti":                                        "Soulrend damage multiplier",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulrendHealMulti":                                          "Soulrend heal multiplier",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulrendRadius":                                             "Soulrend radius",
@@ -1410,13 +1462,13 @@
 
   "text.autoconfig.simplyswords_main.option.unique_effects.ferocityChance.@PrefixText" :                                "§6[Twisted Blade]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.ferocityChance":                                             "Ferocity chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.ferocityDuration":                                           "Ferocity duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.ferocityDuration":                                           "Ferocity duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.ferocityMaxStacks":                                          "Ferocity max stacks",
   "text.autoconfig.simplyswords_main.option.unique_effects.ferocityStrengthTier":                                       "Ferocity strength amplifier",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.emberIreChance.@PrefixText" :                                "§6[Emberblade]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.emberIreChance":                                             "Ember Ire chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.emberIreDuration":                                           "Ember Ire duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.emberIreDuration":                                           "Ember Ire duration":
 
   "text.autoconfig.simplyswords_main.option.unique_effects.volcanicFuryChance.@PrefixText" :                            "§6[Hearthflame]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.volcanicFuryChance":                                         "Volcanic Fury chance",
@@ -1430,7 +1482,7 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.stormRadius":                                                "Storm radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.stormCooldown":                                                "Storm cooldown",
   "text.autoconfig.simplyswords_main.option.unique_effects.stormFrequency":                                                "Storm frequency",
-  "text.autoconfig.simplyswords_main.option.unique_effects.stormDuration":                                                "Storm duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.stormDuration":                                                "Storm duration":
 
   "text.autoconfig.simplyswords_main.option.unique_effects.plagueChance.@PrefixText" :                                  "§6[Longsword of The Plague]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.plagueChance":                                               "Plague chance",
@@ -1444,16 +1496,16 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.soultetherRange.@PrefixText" :                               "§6[Soulpyre]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.soultetherRange":                                            "Soultether range",
   "text.autoconfig.simplyswords_main.option.unique_effects.soultetherRadius":                                           "Soultether radius",
-  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherDuration":                                         "Soultether duration",
-  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherIgniteDuration":                                   "Soultether Ignite duration",
-  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherResistanceDuration":                               "Soultether Resistance duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherDuration":                                         "Soultether duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherIgniteDuration":                                   "Soultether Ignite duration":
+  "text.autoconfig.simplyswords_main.option.unique_effects.soultetherResistanceDuration":                               "Soultether Resistance duration":
 
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryCooldown.@PrefixText" :                             "§6[Frostfall]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryCooldown":                                          "Frost Fury cooldown",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryRadius":                                            "Frost Fury radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryDamage":                                            "Frost Fury damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryChance":                                            "Frost Fury chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryDuration":                                          "Frost Fury duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.frostFuryDuration":                                          "Frost Fury duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.frostFurySpellScaling":                                      "Frost Fury Spell Power DMG multi",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarCooldown.@PrefixText" :                            "§6[Molten Edge]§7",
@@ -1461,19 +1513,19 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarRadius":                                           "Molten Roar radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarKnockbackStrength":                                "Molten Roar Knockback strength",
   "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarChance":                                           "Molten Roar chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarDuration":                                         "Molten Roar duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.moltenRoarDuration":                                         "Molten Roar duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterRadius.@PrefixText" :                            "§6[Livyatan]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterRadius":                                         "Frost Shatter radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterDamage":                                         "Frost Shatter damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterChance":                                         "Frost Shatter chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterDuration":                                       "Frost Shatter duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterDuration":                                       "Frost Shatter duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.frostShatterSpellScaling":                                   "Frost Shatter Spell Power DMG multi",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.permafrostRadius.@PrefixText" :                              "§6[Icewhisper]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.permafrostRadius":                                           "Permafrost radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.permafrostDamage":                                           "Permafrost damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.permafrostCooldown":                                         "Permafrost cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.permafrostDuration":                                         "Permafrost duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.permafrostDuration":                                         "Permafrost duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.permafrostSpellScaling":                                     "Permafrost Spell Power DMG multi",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultRadius.@PrefixText" :                           "§6[Arcanethyst]§7",
@@ -1481,7 +1533,7 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultDamage":                                        "Arcane Assault damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultCooldown":                                      "Arcane Assault cooldown",
   "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultChance":                                        "Arcane Assault chance",
-  "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultDuration":                                      "Arcane Assault duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultDuration":                                      "Arcane Assault duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.arcaneAssaultSpellScaling":                                  "Arcane Assault Spell Power DMG multi",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.thunderBlitzRadius.@PrefixText" :                            "§6[Thunderbrand]§7",
@@ -1500,7 +1552,7 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishAbsorptionCap":                                   "Soul Anguish absorption cap",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishDamage":                                          "Soul Anguish damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishCooldown":                                        "Soul Anguish cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishDuration":                                        "Soul Anguish duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishDuration":                                        "Soul Anguish duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishHeal":                                            "Soul Anguish heal",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishRange":                                           "Soul Anguish range",
   "text.autoconfig.simplyswords_main.option.unique_effects.soulAnguishSpellScaling":                                    "Soul Anguish Spell Power DMG multi",
@@ -1516,7 +1568,7 @@
   "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistCooldown":                                         "Shadowmist cooldown",
   "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistChance":                                           "Shadowmist chance",
   "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistDamageMulti":                                      "Shadowmist damage multiplier",
-  "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistBlindDuration":                                    "Shadowmist Blind duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistBlindDuration":                                    "Shadowmist Blind duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.shadowmistRadius":                                           "Shadowmist radius",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.abyssalStandardCooldown.@PrefixText" :                       "§6[Abyssal Standard]§7",
@@ -1551,32 +1603,32 @@
 
   "text.autoconfig.simplyswords_main.option.unique_effects.hivemindCooldown.@PrefixText" :                              "§6[Hiveheart]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.hivemindCooldown":                                           "Hivemind cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.hivemindDuration":                                           "Hivemind duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.hivemindDuration":                                           "Hivemind duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.hivemindDamage":                                             "Hivemind damage modifier",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeCooldown.@PrefixText" :                        "§6[Star's Edge]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeCooldown":                                     "Celestial Surge cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeDuration":                                     "Celestial Surge duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeDuration":                                     "Celestial Surge duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeStacks":                                       "Celestial Surge Haste stacks",
   "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeDamageModifier":                               "Celestial Surge Damage modifier",
   "text.autoconfig.simplyswords_main.option.unique_effects.celestialSurgeLifestealModifier":                            "Celestial Surge Lifesteal modifier",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.flickerFuryCooldown.@PrefixText" :                           "§6[Wickpiercer]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.flickerFuryCooldown":                                        "Flicker Fury cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.flickerFuryDuration":                                        "Flicker Fury duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.flickerFuryDuration":                                        "Flicker Fury duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.flickerFuryDamage":                                          "Flicker Fury damage modifier",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerDuration.@PrefixText" :                            "§6[Dreadtide]§7",
-  "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerDuration":                                         "Voidcaller duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerDuration":                                         "Voidcaller duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerStartingTickFrequency":                            "Voidcaller starting tick frequency",
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerDamageModifier":                                   "Voidcaller damage modifier",
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerCorruptionFrequency":                              "Voidcaller Corruption frequency",
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerCorruptionPerTick":                                "Voidcaller Corruption per tick",
-  "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerCorruptionDuration":                               "Voidcaller Corruption duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerCorruptionDuration":                               "Voidcaller Corruption duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.voidcallerCorruptionMax":                                    "Voidcaller Corruption max",
 
   "text.autoconfig.simplyswords_main.option.unique_effects.vortexDuration.@PrefixText" :                                "§6[Tempest]§7",
-  "text.autoconfig.simplyswords_main.option.unique_effects.vortexDuration":                                             "Vortex duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.vortexDuration":                                             "Vortex duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.vortexMaxSize":                                              "Vortex max size",
   "text.autoconfig.simplyswords_main.option.unique_effects.vortexMaxStacks":                                            "Vortex max stacks",
   "text.autoconfig.simplyswords_main.option.unique_effects.vortexSpellScaling":                                         "Vortex Spell Power DMG multi",
@@ -1596,7 +1648,7 @@
 
   "text.autoconfig.simplyswords_main.option.unique_effects.magistormCooldown.@PrefixText" :                           "§6[Magiscythe]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.magistormCooldown":                                                "Magiscythe cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.magistormDuration":                                                  "Magistorm duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.magistormDuration":                                                  "Magistorm duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.magistormRadius":                                                     "Magistorm radius",
   "text.autoconfig.simplyswords_main.option.unique_effects.magistormDamage":                                                   "Magistorm damage",
   "text.autoconfig.simplyswords_main.option.unique_effects.magistormRepairChance":                                          "Magistorm repair chance",
@@ -1623,7 +1675,7 @@
 
   "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftCooldown.@PrefixText" :                           "§6[Caelestis]§7",
   "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftCooldown":                                                "Astral Shift cooldown",
-  "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftDuration":                                                  "Astral Shift duration",
+  "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftDuration":                                                  "Astral Shift duration":
   "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftDamageModifier":                                      "Astral Shift damage modifier",
   "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftDamageMax":                                             "Astral Shift damage max",
   "text.autoconfig.simplyswords_main.option.unique_effects.astralShiftChance":                                                    "Astral Shift avoidance chance",
@@ -1631,52 +1683,52 @@
 
   "text.autoconfig.simplyswords_main.option.runic_effects.swiftnessChance.@PrefixText" :                                "§b[Swiftness]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.swiftnessChance":                                             "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.swiftnessDuration":                                           "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.swiftnessDuration":                                           "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.slowChance.@PrefixText" :                                     "§b[Slow]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.slowChance":                                                  "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.slowDuration":                                                "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.slowDuration":                                                "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.poisonChance.@PrefixText" :                                   "§b[Poison]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.poisonChance":                                                "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.poisonDuration":                                              "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.poisonDuration":                                              "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.freezeChance.@PrefixText" :                                   "§b[Freeze]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.freezeChance":                                                "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.freezeDuration":                                              "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.freezeDuration":                                              "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.wildfireChance.@PrefixText" :                                 "§b[Wildfire]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.wildfireChance":                                              "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.wildfireDuration":                                            "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.wildfireDuration":                                            "Duration":
   "text.autoconfig.simplyswords_main.option.runic_effects.wildfireRadius":                                              "Radius",
 
   "text.autoconfig.simplyswords_main.option.runic_effects.floatChance.@PrefixText" :                                    "§b[Float]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.floatChance":                                                 "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.floatDuration":                                               "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.floatDuration":                                               "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.zephyrChance.@PrefixText" :                                   "§b[Zephyr]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.zephyrChance":                                                "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.zephyrDuration":                                              "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.zephyrDuration":                                              "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.shieldingChance.@PrefixText" :                                "§b[Shielding]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.shieldingChance":                                             "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.shieldingDuration":                                           "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.shieldingDuration":                                           "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.stoneskinChance.@PrefixText" :                                "§b[Stoneskin]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.stoneskinChance":                                             "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.stoneskinDuration":                                           "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.stoneskinDuration":                                           "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.trailblazeChance.@PrefixText" :                               "§b[Trailblaze]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.trailblazeChance":                                            "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.trailblazeDuration":                                          "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.trailblazeDuration":                                          "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.weakenChance.@PrefixText" :                                   "§b[Weaken]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.weakenChance":                                                "Chance",
-  "text.autoconfig.simplyswords_main.option.runic_effects.weakenDuration":                                              "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.weakenDuration":                                              "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.unstableFrequency.@PrefixText" :                              "§b[Unstable]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.unstableFrequency":                                           "Frequency",
-  "text.autoconfig.simplyswords_main.option.runic_effects.unstableDuration":                                            "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.unstableDuration":                                            "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.activeDefenceFrequency.@PrefixText" :                         "§b[Active Defence]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.activeDefenceFrequency":                                      "Frequency",
@@ -1685,7 +1737,7 @@
   "text.autoconfig.simplyswords_main.option.runic_effects.frostWardFrequency.@PrefixText" :                             "§b[Frost Ward]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.frostWardFrequency":                                          "Frequency",
   "text.autoconfig.simplyswords_main.option.runic_effects.frostWardRadius":                                             "Radius",
-  "text.autoconfig.simplyswords_main.option.runic_effects.frostWardDuration":                                           "Duration",
+  "text.autoconfig.simplyswords_main.option.runic_effects.frostWardDuration":                                           "Duration":
 
   "text.autoconfig.simplyswords_main.option.runic_effects.momentumCooldown.@PrefixText" :                               "§b[Momentum]§7",
   "text.autoconfig.simplyswords_main.option.runic_effects.momentumCooldown":                                            "Chance",

--- a/common/src/main/resources/data/jeed/tags/mob_effect/hidden.json
+++ b/common/src/main/resources/data/jeed/tags/mob_effect/hidden.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "simplyswords:storm",
+    "simplyswords:void_assault",
+    "simplyswords:voidcloak",
+    "simplyswords:wildfire"
+  ]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/absorption.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/absorption.json
@@ -1,0 +1,27 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:absorption",
+	"providers": [
+		{
+			"item": "simplyswords:stormbringer"
+		},
+		{
+			"item": "simplyswords:whisperwind"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/darkness.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/darkness.json
@@ -1,0 +1,24 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:darkness",
+	"providers": [
+		{
+		"item": "simplyswords:caelestis"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/fire_resistance.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/fire_resistance.json
@@ -1,0 +1,24 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:fire_resistance",
+	"providers": [
+		{
+		  "item": "simplyswords:soulpyre"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/glowing.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/glowing.json
@@ -1,0 +1,24 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:glowing",
+	"providers": [
+		{
+			"item": "simplyswords:soulstealer"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/haste.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/haste.json
@@ -1,0 +1,54 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:haste",
+	"providers": [
+		{
+			"item": "simplyswords:storms_edge"
+		},
+		{
+			"item": "simplyswords:emberblade"
+		},
+		{
+			"item": "simplyswords:twisted_blade"
+		},
+		{
+			"item": "simplyswords:soulstealer"
+		},
+		{
+			"item": "simplyswords:soulpyre"
+		},
+		{
+			"item": "simplyswords:thunderbrand"
+		},
+		{
+			"item": "simplyswords:harbinger"
+		},
+		{
+			"item": "simplyswords:waxweaver"
+		},
+		{
+			"item": "simplyswords:stars_edge"
+		},
+		{
+			"item": "simplyswords:flamewind"
+		},
+		{
+			"item": "simplyswords:enigma"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/invisibility.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/invisibility.json
@@ -1,0 +1,24 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:invisibility",
+	"providers": [
+		{
+		  "item": "simplyswords:soulstealer"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/levitation.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/levitation.json
@@ -1,0 +1,27 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:levitation",
+	"providers": [
+		{
+			"item": "simplyswords:hearthflame"
+		},
+		{
+			"item": "simplyswords:arcanethyst"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/mining_fatigue.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/mining_fatigue.json
@@ -1,0 +1,36 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:mining_fatigue",
+	"providers": [
+		{
+			"item": "simplyswords:storms_edge"
+		},
+		{
+			"item": "simplyswords:hearthflame"
+		},
+		{
+			"item": "simplyswords:soulkeeper"
+		},
+		{
+			"item": "simplyswords:frostfall"
+		},
+		{
+			"item": "simplyswords:thunderbrand"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/poison.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/poison.json
@@ -1,0 +1,24 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:poison",
+	"providers": [
+		{
+		  "item": "simplyswords:hiveheart"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/regeneration.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/regeneration.json
@@ -1,0 +1,39 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:regeneration",
+	"providers": [
+		{
+			"item": "simplyswords:soulkeeper"
+		},
+		{
+			"item": "simplyswords:frostfall"
+		},
+		{
+			"item": "simplyswords:molten_edge"
+		},
+		{
+			"item": "simplyswords:righteous_relic"
+		},
+		{
+			"item": "simplyswords:sunfire"
+		},
+		{
+			"item": "simplyswords:hiveheart"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/resistance.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/resistance.json
@@ -1,0 +1,54 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:resistance",
+	"providers": [
+		{
+			"item": "simplyswords:storms_edge"
+		},
+		{
+			"item": "simplyswords:soulkeeper"
+		},
+		{
+			"item": "simplyswords:soulpyre"
+		},
+		{
+			"item": "simplyswords:frostfall"
+		},
+		{
+			"item": "simplyswords:molten_edge"
+		},
+		{
+			"item": "simplyswords:livyatan"
+		},
+		{
+			"item": "simplyswords:mjolnir"
+		},
+		{
+			"item": "simplyswords:whisperwind"
+		},
+		{
+			"item": "simplyswords:waxweaver"
+		},
+		{
+			"item": "simplyswords:stars_edge"
+		},
+		{
+			"item": "simplyswords:wickpiercer"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/slowness.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/slowness.json
@@ -1,0 +1,51 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:slowness",
+	"providers": [
+		{
+			"item": "simplyswords:hearthflame"
+		},
+		{
+			"item": "simplyswords:soulstealer"
+		},
+		{
+			"item": "simplyswords:soulrender"
+		},
+		{
+			"item": "simplyswords:soulpyre"
+		},
+		{
+			"item": "simplyswords:frostfall"
+		},
+		{
+			"item": "simplyswords:icewhisper"
+		},
+		{
+			"item": "simplyswords:thunderbrand"
+		},
+		{
+			"item": "simplyswords:sunfire"
+		},
+		{
+			"item": "simplyswords:harbinger"
+		},
+		{
+			"item": "simplyswords:enigma"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/speed.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/speed.json
@@ -1,0 +1,33 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:speed",
+	"providers": [
+		{
+			"item": "simplyswords:storms_edge"
+		},
+		{
+			"item": "simplyswords:emberblade"
+		},
+		{
+			"item": "simplyswords:molten_edge"
+		},
+		{
+			"item": "simplyswords:stars_edge"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/strength.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/strength.json
@@ -1,0 +1,36 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:strength",
+	"providers": [
+		{
+			"item": "simplyswords:emderblade"
+		},
+		{
+			"item": "simplyswords:twisted_blade"
+		},
+		{
+			"item": "simplyswords:molten_edge"
+		},
+		{
+			"item": "simplyswords:sunfire"
+		},
+		{
+			"item": "simplyswords:waxweaver"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/weakness.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/weakness.json
@@ -1,0 +1,30 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:weakness",
+	"providers": [
+		{
+			"item": "simplyswords:soulrender"
+		},
+		{
+			"item": "simplyswords:tainted_relic"
+		},
+		{
+			"item": "simplyswords:harbinger"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/astral_shift.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/astral_shift.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:astral_shift",
+	"providers": [
+		{
+			"item": "simplyswords:caelestis"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/echo.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/echo.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:echo",
+	"providers": [
+		{
+			"item": "simplyswords:whisperwind"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/elemental_vortex.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/elemental_vortex.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:elemental_vortex",
+	"providers": [
+		{
+			"item": "simplyswords:tempest"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/fatal_flicker.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/fatal_flicker.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:fatal_flicker",
+	"providers": [
+		{
+			"item": "simplyswords:whisperwind"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/fire_vortex.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/fire_vortex.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:fire_vortex",
+	"providers": [
+		{
+			"item": "simplyswords:tempest"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/flameseed.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/flameseed.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:flameseed",
+	"providers": [
+		{
+			"item": "simplyswords:flamewind"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/freeze.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/freeze.json
@@ -1,0 +1,29 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:freeze",
+	"providers": [
+		{
+			"item": "simplyswords:soulpyre"
+		},
+		{
+			"item": "simplyswords:frostfall"
+		},
+		{
+			"item": "simplyswords:livyatan"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/frenzy.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/frenzy.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:frenzy",
+	"providers": [
+		{
+			"item": "simplyswords:wickpiercer"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/frost_vortex.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/frost_vortex.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:frost_vortex",
+	"providers": [
+		{
+			"item": "simplyswords:tempest"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/magislam.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/magislam.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:magislam",
+	"providers": [
+		{
+			"item": "simplyswords:magispear"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/magistorm.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/magistorm.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:magistorm",
+	"providers": [
+		{
+			"item": "simplyswords:magiscythe"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/onslaught.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/onslaught.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:onslaught",
+	"providers": [
+		{
+			"item": "simplyswords:molten_edge"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/pain.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/pain.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:pain",
+	"providers": [
+		{
+			"item": "simplyswords:enigma"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/resilience.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/resilience.json
@@ -1,0 +1,26 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:resilience",
+	"providers": [
+		{
+			"item": "simplyswords:ribboncleaver"
+		},
+		{
+			"item": "simplyswords:magispear"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/ribboncleave.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/ribboncleave.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:ribboncleave",
+	"providers": [
+		{
+			"item": "simplyswords:ribboncleaver"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/ribbonwrath.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/ribbonwrath.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:ribbonwrath",
+	"providers": [
+		{
+			"item": "simplyswords:ribboncleaver"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/smouldering.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/smouldering.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:smouldering",
+	"providers": [
+		{
+			"item": "simplyswords:emberlash"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/spore_swarm.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/spore_swarm.json
@@ -1,0 +1,23 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:spore_swarm",
+	"providers": [
+		{
+			"item": "simplyswords:bramblethorn"
+		}
+	],
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/ward.json
+++ b/common/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/ward.json
@@ -1,0 +1,134 @@
+{
+  "type": "jeed:effect_provider",
+  "effect": "simplyswords:ward",
+  "providers": [
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_longsword"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_twinblade"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_rapier"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_katana"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_sai"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_spear"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_glaive"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_cutlass"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_claymore"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_chakram"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_greataxe"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_greathammer"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_warglaive"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_scythe"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    },
+	{
+      "fabric:type": "fabric:nbt",
+      "base": {
+        "item": "simplyswords:runic_halberd"
+      },
+      "nbt": "{\"runic_power\": \"ward\"}",
+      "strict": true
+    }
+  ],
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "jeed"
+      ]
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/absorption.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/absorption.json
@@ -1,0 +1,31 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:absorption",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"shielding\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"greater_shielding\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/dolphins_grace.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/dolphins_grace.json
@@ -1,0 +1,23 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:dolphins_grace",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"unstable\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/fire_resistance.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/fire_resistance.json
@@ -1,0 +1,39 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:fire_resistance",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"stoneskin\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"greater_stoneskin\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"unstable\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/haste.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/haste.json
@@ -1,0 +1,47 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:haste",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"unstable\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"zephyr\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"greater_zephyr\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:netherfused_gem"
+			},
+			"nbt": "{\"nether_power\": \"onslaught\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/invisibility.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/invisibility.json
@@ -1,0 +1,23 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:invisibility",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"unstable\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/jump_boost.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/jump_boost.json
@@ -1,0 +1,23 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:jump_boost",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"unstable\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/levitation.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/levitation.json
@@ -1,0 +1,39 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:levitation",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"float\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"greater_float\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"unstable\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/regeneration.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/regeneration.json
@@ -1,0 +1,23 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:regeneration",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"unstable\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/resistance.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/resistance.json
@@ -1,0 +1,31 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:resistance",
+	"providers": [
+	{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"stoneskin\"}",
+			"strict": "true"
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"unstable\"}",
+			"strict": "true"
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/slow_falling.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/slow_falling.json
@@ -1,0 +1,23 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:slow_falling",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"unstable\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/slowness.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/slowness.json
@@ -1,0 +1,71 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:slowness",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"frost_ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"slow\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"greater_slow\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"stoneskin\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"greater_stoneskin\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"weaken\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"greater_weaken\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/speed.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/speed.json
@@ -1,0 +1,71 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:speed",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"swiftness\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"greater_swiftness\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"trailblaze\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"greater_trailblaze\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"unstable\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"zephyr\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"greater_zephyr\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/weakness.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/weakness.json
@@ -1,0 +1,47 @@
+{
+	"replace": false,
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:weakness",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"unstable\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"weaken\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"greater_weaken\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:netherfused_gem"
+			},
+			"nbt": "{\"nether_power\": \"onslaught\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/battle_fatigue.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/battle_fatigue.json
@@ -1,0 +1,22 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:battle_fatigue",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:netherfused_gem"
+			},
+			"nbt": "{\"nether_power\": \"nullification\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/echo.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/echo.json
@@ -1,0 +1,22 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:echo",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:netherfused_gem"
+			},
+			"nbt": "{\"nether_power\": \"echo\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/freeze.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/freeze.json
@@ -1,0 +1,22 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:freeze",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runefused_gem"
+			},
+			"nbt": "{\"runic_power\": \"freeze\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/immolation.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/immolation.json
@@ -1,0 +1,142 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:immolation",
+	"providers": [
+	{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_longsword"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_twinblade"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_rapier"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_katana"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_sai"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_spear"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_glaive"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_cutlass"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_claymore"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_chakram"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_greataxe"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_greathammer"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_warglaive"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_scythe"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_halberd"
+			},
+			"nbt": "{\"runic_power\": \"immolation\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:netherfused_gem"
+			},
+			"nbt": "{\"nether_power\": \"radiance\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/onslaught.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/onslaught.json
@@ -1,0 +1,22 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:onslaught",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:netherfused_gem"
+			},
+			"nbt": "{\"nether_power\": \"onslaught\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/ward.json
+++ b/fabric/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/ward.json
@@ -1,0 +1,134 @@
+{
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:ward",
+	"providers": [
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_longsword"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_twinblade"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_rapier"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_katana"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_sai"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_spear"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_glaive"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_cutlass"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_claymore"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_chakram"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_greataxe"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_greathammer"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_warglaive"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_scythe"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		},
+		{
+			"fabric:type": "fabric:nbt",
+			"base": {
+				"item": "simplyswords:runic_halberd"
+			},
+			"nbt": "{\"runic_power\": \"ward\"}",
+			"strict": true
+		}
+	],
+	"fabric:load_conditions": [
+		{
+			"condition": "fabric:all_mods_loaded",
+			"values": [
+				"jeed"
+			]
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/absorption.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/absorption.json
@@ -1,0 +1,27 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:absorption",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "shielding"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "greater_shielding"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/dolphins_grace.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/dolphins_grace.json
@@ -1,0 +1,20 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:dolphins_grace",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "unstable"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/fire_resistance.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/fire_resistance.json
@@ -1,0 +1,34 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:fire_resistance",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "stoneskin"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "greater_stoneskin"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "unstable"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/haste.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/haste.json
@@ -1,0 +1,41 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:haste",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "unstable"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "zephyr"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "greater_zephyr"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:netherfused_gem",
+			"nbt": {
+				"runic_power": "onslaught"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/invisibility.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/invisibility.json
@@ -1,0 +1,20 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:invisibility",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "unstable"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/jump_boost.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/jump_boost.json
@@ -1,0 +1,20 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:jump_boost",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "unstable"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/levitation.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/levitation.json
@@ -1,0 +1,34 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:levitation",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "float"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "greater_float"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "unstable"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/regeneration.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/regeneration.json
@@ -1,0 +1,20 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:regeneration",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "unstable"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/resistance.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/resistance.json
@@ -1,0 +1,27 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:resistance",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "stoneskin"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "unstable"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/slow_falling.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/slow_falling.json
@@ -1,0 +1,20 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:slow_falling",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "unstable"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/slowness.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/slowness.json
@@ -1,0 +1,62 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:slowness",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused",
+			"nbt": {
+				"runic_power": "frost_ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused",
+			"nbt": {
+				"runic_power": "slow"
+				}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused",
+			"nbt": {
+				"runic_power": "greater_slow"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused",
+			"nbt": {
+				"runic_power": "stoneskin"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused",
+			"nbt": {
+				"runic_power": "greater_stoneskin"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused",
+			"nbt": {
+				"runic_power": "weaken"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused",
+			"nbt": {
+				"runic_power": "greater_weaken"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/speed.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/speed.json
@@ -1,0 +1,62 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:speed",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "swiftness"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "greater_swiftness"
+			}
+		},		
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "trailblaze"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "greater_trailblaze"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "unstable"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "zephyr"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "greater_zephyr"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/weakness.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/minecraft/weakness.json
@@ -1,0 +1,41 @@
+{
+	"replace": false,
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "minecraft:weakness",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "unstable"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "weaken"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "onslaught"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:netherfused_gem",
+			"nbt": {
+				"runic_power": "onslaught"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/battle_fatigue.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/battle_fatigue.json
@@ -1,0 +1,19 @@
+{
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:battle_fatigue",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:netherfused_gem",
+			"nbt": {
+				"runic_power": "nullification"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/echo.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/echo.json
@@ -1,0 +1,22 @@
+{
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:echo",
+	"providers": [
+		{
+			"item": "simplyswords:whisperwind"
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:netherfused_gem",
+			"nbt": {
+				"runic_power": "echo"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/freeze.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/freeze.json
@@ -1,0 +1,19 @@
+{
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:freeze",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runefused_gem",
+			"nbt": {
+				"runic_power": "freeze"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/immolation.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/immolation.json
@@ -1,0 +1,124 @@
+{
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:immolation",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_longsword",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_twinblade",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_rapier",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_katana",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_sai",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_spear",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_glaive",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_cutlass",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_claymore",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_chakram",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_greataxe",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_greathammer",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_warglaive",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_scythe",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_halberd",
+			"nbt": {
+				"runic_power": "immolation"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:netherfused_gem",
+			"nbt": {
+				"runic_power": "radiance"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/onslaught.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/onslaught.json
@@ -1,0 +1,19 @@
+{
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:onslaught",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:netherfused_gem",
+			"nbt": {
+				"runic_power": "onslaught"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/ward.json
+++ b/forge/src/main/resources/data/simplyswords/recipes/compat/jeed/simplyswords/ward.json
@@ -1,0 +1,117 @@
+{
+	"conditions": [
+		{
+			"modid": "jeed",
+			"type": "forge:mod_loaded"
+		}
+	],
+	"type": "jeed:effect_provider",
+	"effect": "simplyswords:ward",
+	"providers": [
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_longsword",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_twinblade",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_rapier",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_katana",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_sai",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_spear",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_glaive",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_cutlass",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_claymore",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_chakram",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_greataxe",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_greathammer",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_warglaive",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_scythe",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		},
+		{
+			"type": "forge:nbt",
+			"item": "simplyswords:runic_halberd",
+			"nbt": {
+				"runic_power": "ward"
+			}
+		}
+	]
+}


### PR DESCRIPTION
### Goals
* Adds Just Enough Effect Descriptions recipes for effects
* Adds translation keys for effect descriptions
* Hides currently unused effects through use of `#jeed:hidden` mob effect tag
* Support for both Forge and Fabric mod loader

### Notes
**Has not been tested fully.**

Originally, the files were combined only for Fabric; however, for the purpose of organization and fun NBT stuff within recipes, I separated the recipes into three categories: Common, Fabric, and Forge. The Common recipes don't have specified NBTs since they specify only the weapons; the Fabric and Forge recipes do for the runefused gems, netherfused gems, and runic weapons.