### PR TITLE
Fixed several uniques when in the offhand

### DIFF
--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/ArcanethystSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/ArcanethystSwordItem.java
@@ -68,7 +68,7 @@ public class ArcanethystSwordItem extends UniqueSwordItem implements TwoHandedWe
 
     @Override
     public void usageTick(World world, LivingEntity user, ItemStack stack, int remainingUseTicks) {
-        if (user.getEquippedStack(EquipmentSlot.MAINHAND) == stack && user instanceof PlayerEntity) {
+        if (HelperMethods.isHolding(stack, user) && user instanceof PlayerEntity) {
             int radius = Config.uniqueEffects.arcaneAssault.radius;
             float abilityDamage = HelperMethods.spellScaledDamage("arcane", user, Config.uniqueEffects.arcaneAssault.spellScaling, Config.uniqueEffects.arcaneAssault.damage);
             AbilityMethods.tickAbilityArcaneAssault(stack, world, user, remainingUseTicks, abilityDamage, radius);

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/IcewhisperSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/IcewhisperSwordItem.java
@@ -49,6 +49,7 @@ public class IcewhisperSwordItem extends UniqueSwordItem implements TwoHandedWea
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack itemStack = user.getStackInHand(hand);
+
         if (itemStack.getDamage() >= itemStack.getMaxDamage() - 1) {
             return TypedActionResult.fail(itemStack);
         }
@@ -60,7 +61,7 @@ public class IcewhisperSwordItem extends UniqueSwordItem implements TwoHandedWea
 
     @Override
     public void usageTick(World world, LivingEntity user, ItemStack stack, int remainingUseTicks) {
-        if (user.getEquippedStack(EquipmentSlot.MAINHAND) == stack && user instanceof PlayerEntity) {
+        if (HelperMethods.isHolding(stack, user) && user instanceof PlayerEntity) {
 
             ChargedLocationComponent location = stack.getOrDefault(ComponentTypeRegistry.CHARGED_LOCATION.get(), ChargedLocationComponent.DEFAULT);
             int radius = Config.uniqueEffects.permafrost.radius;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/LichbladeSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/LichbladeSwordItem.java
@@ -54,6 +54,10 @@ public class LichbladeSwordItem extends UniqueSwordItem implements TwoHandedWeap
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         ItemStack itemStack = user.getStackInHand(hand);
+        if(hand == Hand.OFF_HAND) {
+            return TypedActionResult.fail(itemStack);
+        }
+
         if (itemStack.getDamage() >= itemStack.getMaxDamage() - 1) {
             return TypedActionResult.fail(itemStack);
         }

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/StormsEdgeSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/StormsEdgeSwordItem.java
@@ -66,7 +66,7 @@ public class StormsEdgeSwordItem extends UniqueSwordItem {
 
     @Override
     public void usageTick(World world, LivingEntity user, ItemStack stack, int remainingUseTicks) {
-        if (!world.isClient && user.getEquippedStack(EquipmentSlot.MAINHAND) == stack) {
+        if (!world.isClient && HelperMethods.isHolding(stack, user)) {
             int skillCooldown = Config.uniqueEffects.stormJolt.cooldown;
             AbilityMethods.tickAbilityStormJolt(stack, world, user, remainingUseTicks, skillCooldown, radius);
         }
@@ -75,7 +75,7 @@ public class StormsEdgeSwordItem extends UniqueSwordItem {
     @Override
     public void onStoppedUsing(ItemStack stack, World world, LivingEntity user, int remainingUseTicks) {
         //Player dash end
-        if (!world.isClient && user.getEquippedStack(EquipmentSlot.MAINHAND) == stack) {
+        if (!world.isClient && HelperMethods.isHolding(stack, user)) {
             user.setVelocity(0, 0, 0); // Stop player at end of charge
             user.velocityModified = true;
             user.addStatusEffect(new StatusEffectInstance(StatusEffects.HASTE, 80, 1), user);

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/ThunderbrandSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/ThunderbrandSwordItem.java
@@ -69,7 +69,7 @@ public class ThunderbrandSwordItem extends UniqueSwordItem implements TwoHandedW
 
     @Override
     public void usageTick(World world, LivingEntity user, ItemStack stack, int remainingUseTicks) {
-        if (!world.isClient && user.getEquippedStack(EquipmentSlot.MAINHAND) == stack && user.isOnGround()) {
+        if (!world.isClient && HelperMethods.isHolding(stack, user) && user.isOnGround()) {
 
             float abilityDamage = HelperMethods.spellScaledDamage("lightning", user, Config.uniqueEffects.thunderBlitz.spellScaling, Config.uniqueEffects.thunderBlitz.damage);
             int skillCooldown = Config.uniqueEffects.thunderBlitz.cooldown;

--- a/common/src/main/java/net/sweenus/simplyswords/util/AbilityMethods.java
+++ b/common/src/main/java/net/sweenus/simplyswords/util/AbilityMethods.java
@@ -29,7 +29,7 @@ public class AbilityMethods {
         if (!user.getWorld().isClient()) {
 
             //Player dash forward
-            if (ability_timer == 12 || ability_timer == 13 && user.getEquippedStack(EquipmentSlot.MAINHAND) == stack) {
+            if (ability_timer == 12 || ability_timer == 13 && HelperMethods.isHolding(stack, user)) {
                 user.setVelocity(user.getRotationVector().multiply(+4));
                 user.setVelocity(user.getVelocity().x, 0, user.getVelocity().z); // Prevent user flying to the heavens
                 user.velocityModified = true;
@@ -41,14 +41,14 @@ public class AbilityMethods {
             }
 
             //Player dash end
-            if (ability_timer < 5 && user.getEquippedStack(EquipmentSlot.MAINHAND) == stack) {
+            if (ability_timer < 5 && HelperMethods.isHolding(stack, user)) {
                 user.setVelocity(0, 0, 0); // Stop user at end of charge
                 user.velocityModified = true;
                 user.addStatusEffect(new StatusEffectInstance(StatusEffects.HASTE, 80, 1), user);
 
             }
 
-            if (user.age % 2 == 0 && user.getEquippedStack(EquipmentSlot.MAINHAND) == stack) {
+            if (user.age % 2 == 0 && HelperMethods.isHolding(stack, user)) {
                 double xpos = user.getX() - (radius + 1);
                 double ypos = user.getY();
                 double zpos = user.getZ() - (radius + 1);
@@ -141,7 +141,7 @@ public class AbilityMethods {
             }
 
             //AOE Damage & charge control
-            if (user.age % 3 == 0 && user.getEquippedStack(EquipmentSlot.MAINHAND) == stack) {
+            if (user.age % 3 == 0 && HelperMethods.isHolding(stack, user)) {
                 Box box = new Box(user.getX() + radius, user.getY() + radius * 2, user.getZ() + radius,
                         user.getX() - radius, user.getY() - radius, user.getZ() - radius);
                 for (Entity entity : world.getOtherEntities(user, box, EntityPredicates.VALID_LIVING_ENTITY)) {
@@ -247,7 +247,7 @@ public class AbilityMethods {
         if (ability_timer < 5) user.stopUsingItem();
 
         //AOE Blizzard
-        if (user.age % 10 != 0 || user.getEquippedStack(EquipmentSlot.MAINHAND) != stack) return;
+        if (user.age % 10 != 0 || !HelperMethods.isHolding(stack, user)) return;
 
         if (user instanceof PlayerEntity player) {
             player.getHungerManager().addExhaustion(0.8f);
@@ -304,7 +304,7 @@ public class AbilityMethods {
             if (ability_timer < 5) user.stopUsingItem();
 
             //AOE Lift - 1 charge
-            if (user.age % 10 == 0 && user.getEquippedStack(EquipmentSlot.MAINHAND) == stack) {
+            if (user.age % 10 == 0 && HelperMethods.isHolding(stack, user)) {
                 Box box = new Box(user.getX() + radius, user.getY() + radius * 2, user.getZ() + radius,
                         user.getX() - radius, user.getY() - radius, user.getZ() - radius);
                 for (Entity entity : world.getOtherEntities(user, box, EntityPredicates.VALID_LIVING_ENTITY)) {

--- a/common/src/main/java/net/sweenus/simplyswords/util/HelperMethods.java
+++ b/common/src/main/java/net/sweenus/simplyswords/util/HelperMethods.java
@@ -474,4 +474,9 @@ public class HelperMethods {
         return false;
     }
 
+    public static boolean isHolding(ItemStack stack, LivingEntity entity) {
+        return entity.getEquippedStack(EquipmentSlot.MAINHAND).equals(stack)
+                || entity.getEquippedStack(EquipmentSlot.OFFHAND).equals(stack);
+    }
+
 }


### PR DESCRIPTION
### Lichblade
Lichblade's active commands the souls to attack a target. As these souls do not exist when in the offhand, you may no longer use the active ability in the offhand.

### Storm's Edge, Icewhisper, Arcanethyst & Thunderbrand
All of these abilities now work correctly in the offhand, so long as better combat is disabled (which keeps in line with other 2-handed uniques like Star's Edge). Attempting to use them before would only use part of their ability, now the full ability will be used.

Icewhisper's passive frost aura is still exclusive to the mainhand.

This was made to fix [this issue](https://github.com/Sweenus/SimplySwords/issues/211)