### PR TITLE
Continued Offhand Fixes

### DIFF
--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/HearthflameSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/HearthflameSwordItem.java
@@ -84,7 +84,7 @@ public class HearthflameSwordItem extends UniqueSwordItem implements TwoHandedWe
 
     @Override
     public void usageTick(World world, LivingEntity user, ItemStack stack, int remainingUseTicks) {
-        if (user.getEquippedStack(EquipmentSlot.MAINHAND) == stack && (user instanceof PlayerEntity player)) {
+        if (HelperMethods.isHolding(stack, user) && user instanceof PlayerEntity player) {
             int radius = Config.uniqueEffects.volcanicFury.radius;
             float spellScaling = HelperMethods.commonSpellAttributeScaling(Config.uniqueEffects.volcanicFury.spellScaling, user, "fire");
             float abilityDamage = spellScaling > 0f ? spellScaling : Config.uniqueEffects.volcanicFury.damage;

--- a/common/src/main/java/net/sweenus/simplyswords/util/AbilityMethods.java
+++ b/common/src/main/java/net/sweenus/simplyswords/util/AbilityMethods.java
@@ -353,7 +353,7 @@ public class AbilityMethods {
         }
     }
 
-    //Thunder Brand - Thunder Blitz
+    //Hearthflame - Volcanic Fury
     public static void tickAbilityVolcanicFury(ItemStack stack, World world, LivingEntity user,
                                                int ability_timer, int ability_timer_max, float abilityDamage,
                                                int skillCooldown, int radius, int chargePower) {
@@ -362,7 +362,7 @@ public class AbilityMethods {
             if (ability_timer < 5) user.stopUsingItem();
 
             //AOE Damage
-            if (user.age % 20 == 0 && user.getEquippedStack(EquipmentSlot.MAINHAND) == stack) {
+            if (user.age % 20 == 0 && HelperMethods.isHolding(stack, user)) {
 
                 if (ability_timer > 10) {
                     user.addStatusEffect(new StatusEffectInstance(StatusEffects.SLOWNESS, 20, 5), user);

--- a/common/src/main/resources/assets/simplyswords/models/item/template_twinblade.json
+++ b/common/src/main/resources/assets/simplyswords/models/item/template_twinblade.json
@@ -17,6 +17,11 @@
 			"translation": [1, 4, 1],
 			"scale": [1.36, 1.36, 0.68]
 		},
+		"firstperson_lefthand": {
+			"rotation": [0, 90, -25],
+			"translation": [1, 4, 1],
+			"scale": [1.36, 1.36, 0.68]
+		},
 		"ground": {
 			"translation": [0, 4, 0],
 			"scale": [1, 1, 0.5]


### PR DESCRIPTION
# Hearthflame
Heathflame is now usable in the offhand, just like the other weapons fixed in #241 

# Twinblades
Fixed twinblades being held incorrectly in the offhand compared to the mainhand. This includes the twinblade uniques.