### PR TITLE
Various Bug Fixes

### DIFF
--- a/common/src/main/java/net/sweenus/simplyswords/client/api/SimplySwordsClientAPI.java
+++ b/common/src/main/java/net/sweenus/simplyswords/client/api/SimplySwordsClientAPI.java
@@ -39,7 +39,7 @@ public class SimplySwordsClientAPI {
         if (itemStack.getItem() instanceof UniqueSwordItem) {
             entry = TooltipUtils.handleUniqueSwordTooltip(itemStack, tooltipContext, tooltip, type, uniquePath);
         } else if (itemStack.getItem() instanceof RunicSwordItem) {
-            entry = TooltipUtils.handleRunicSwordTooltip(itemStack, tooltipContext, tooltip, type, modId, itemPath, runicPath);
+            entry = TooltipUtils.handleRunicSwordTooltip(itemStack, tooltipContext, tooltip, type, itemPath, runicPath);
         }
 
         // Process Control + Alt key events for navigation

--- a/common/src/main/java/net/sweenus/simplyswords/client/util/TooltipUtils.java
+++ b/common/src/main/java/net/sweenus/simplyswords/client/util/TooltipUtils.java
@@ -154,7 +154,7 @@ public class TooltipUtils {
                 itemStack.getItem().getRegistryEntry().registryKey().getValue().getPath() + ".mdx");
     }
 
-    public static Identifier handleRunicSwordTooltip(ItemStack itemStack, Item.TooltipContext tooltipContext, List<Text> tooltip, TooltipType type, String modId, String itemPath, String runicPath) {
+    public static Identifier handleRunicSwordTooltip(ItemStack itemStack, Item.TooltipContext tooltipContext, List<Text> tooltip, TooltipType type, String itemPath, String runicPath) {
         tooltip.add(Text.literal(""));
 
         GemPowerComponent component = SimplySwordsAPI.getComponent(itemStack);
@@ -167,7 +167,7 @@ public class TooltipUtils {
             if (!Platform.isNeoForge()) { // NeoForge / Architectury 1.21.1 conflict. Have to disable this on NeoForge. Can re-enable post 1.21.3 :/
                 RegistryEntry<GemPower> mainComponent = component.runicPower();
                 String powerId = mainComponent.getIdAsString()
-                        .replace(modId + ":", "")
+                        .replaceAll("[A-Za-z0-9_-]+:", "")
                         .replace("greater_", "");
                 return Identifier.of(runicPath + "/" + powerId + ".mdx");
             }

--- a/common/src/main/java/net/sweenus/simplyswords/config/UniqueEffectsConfig.java
+++ b/common/src/main/java/net/sweenus/simplyswords/config/UniqueEffectsConfig.java
@@ -57,12 +57,12 @@ public class UniqueEffectsConfig extends Config {
     public WraithfangSwordItem.EffectSettings wraithfang = new WraithfangSwordItem.EffectSettings();
 
     // eldritch end compat
-    public ValidatedCondition<DreadtideSwordItem.EffectSettings> voidcaller = new ValidatedAny<>(new DreadtideSwordItem.EffectSettings())
+    public ValidatedCondition<DreadtideSwordItem.EffectSettings> dreadtide = new ValidatedAny<>(new DreadtideSwordItem.EffectSettings())
             .toCondition(
                     () -> SimplySwords.passVersionCheck("eldritch_end", SimplySwords.minimumEldritchEndVersion),
-                    Text.translatable("simplyswords.unique_effects.voidcaller.compat"),
+                    Text.translatable("simplyswords.unique_effects.dreadtide.compat"),
 					DreadtideSwordItem.EffectSettings::new
-            ).withFailTitle(Text.translatable("simplyswords.unique_effects.voidcaller.compat.failTitle"));
+            ).withFailTitle(Text.translatable("simplyswords.unique_effects.dreadtide.compat.failTitle"));
 
 //EffectSettings
         //much like the gem power settings, each setting block is stored within the sword item it's used for

--- a/common/src/main/java/net/sweenus/simplyswords/effect/VoidAssaultEffect.java
+++ b/common/src/main/java/net/sweenus/simplyswords/effect/VoidAssaultEffect.java
@@ -26,7 +26,7 @@ public class VoidAssaultEffect extends OrbitingEffect {
     @Override
     public boolean applyUpdateEffect(LivingEntity livingEntity, int amplifier) {
         if (!livingEntity.getWorld().isClient()) {
-            int voidcallerStartingTickFrequency = Config.uniqueEffects.voidcaller.get().startingTickFrequency;
+            int voidcallerStartingTickFrequency = Config.uniqueEffects.dreadtide.get().startingTickFrequency;
 
             if (livingEntity.getStatusEffect(EffectRegistry.getReference(EffectRegistry.VOIDASSAULT)) instanceof SimplySwordsStatusEffectInstance statusEffect) {
                 sourceEntity = statusEffect.getSourceEntity();

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/DreadtideSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/DreadtideSwordItem.java
@@ -55,8 +55,8 @@ public class DreadtideSwordItem extends UniqueSwordItem {
     @Override
     public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
         if (!user.getWorld().isClient() && world instanceof  ServerWorld serverWorld) {
-            int voidcallerDuration = Config.uniqueEffects.voidcaller.get().duration;
-            float voidcallerDamageModifier = Config.uniqueEffects.voidcaller.get().damageModifier;
+            int voidcallerDuration = Config.uniqueEffects.dreadtide.get().duration;
+            float voidcallerDamageModifier = Config.uniqueEffects.dreadtide.get().damageModifier;
             int skillCooldown = 20;
 
             Box box = HelperMethods.createBox(user, 10);

--- a/common/src/main/java/net/sweenus/simplyswords/util/ModLootTableModifiers.java
+++ b/common/src/main/java/net/sweenus/simplyswords/util/ModLootTableModifiers.java
@@ -9,6 +9,7 @@ import net.minecraft.loot.LootPool;
 import net.minecraft.loot.LootTable;
 import net.minecraft.loot.condition.RandomChanceLootCondition;
 import net.minecraft.loot.entry.ItemEntry;
+import net.minecraft.loot.function.EnchantRandomlyLootFunction;
 import net.minecraft.loot.provider.number.ConstantLootNumberProvider;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.RegistryKey;
@@ -40,7 +41,7 @@ public class ModLootTableModifiers {
                     LootPool.Builder pool = LootPool.builder()
                             .rolls(ConstantLootNumberProvider.create(1))
                             .conditionally(RandomChanceLootCondition.builder(LootConfig.INSTANCE.standardLootTableWeight.get() / 100))
-                            .apply(EnchantRandomlyFromTagLootFunction.create(EnchantmentTags.DAMAGE_EXCLUSIVE_SET))
+                            .apply(EnchantRandomlyLootFunction.create())
                             .with(ItemEntry.builder(ItemsRegistry.IRON_LONGSWORD.get()))
                             .with(ItemEntry.builder(ItemsRegistry.IRON_TWINBLADE.get()))
                             .with(ItemEntry.builder(ItemsRegistry.IRON_RAPIER.get()))
@@ -85,7 +86,7 @@ public class ModLootTableModifiers {
                     LootPool.Builder pool = LootPool.builder()
                             .rolls(ConstantLootNumberProvider.create(1))
                             .conditionally(RandomChanceLootCondition.builder(LootConfig.INSTANCE.rareLootTableWeight.get() / 100))
-                            .apply(EnchantRandomlyFromTagLootFunction.create(EnchantmentTags.DAMAGE_EXCLUSIVE_SET)) //This is not ideal, but forge doesn't expose the registry wrapper so...
+                            .apply(EnchantRandomlyLootFunction.create()) //This is not ideal, but forge doesn't expose the registry wrapper so...
                             .with(ItemEntry.builder(ItemsRegistry.DIAMOND_LONGSWORD.get()))
                             .with(ItemEntry.builder(ItemsRegistry.DIAMOND_TWINBLADE.get()))
                             .with(ItemEntry.builder(ItemsRegistry.DIAMOND_RAPIER.get()))

--- a/common/src/main/resources/assets/simplyswords/lang/en_us.json
+++ b/common/src/main/resources/assets/simplyswords/lang/en_us.json
@@ -1248,6 +1248,7 @@
   "simplyswords.weapon_attributes.uniqueDamageModifier.magispear_damageModifier": "§6Magispear§7 damage modifier",
   "simplyswords.weapon_attributes.uniqueDamageModifier.magiblade_damageModifier": "§6Magiblade§7 damage modifier",
   "simplyswords.weapon_attributes.uniqueDamageModifier.caelestis_damageModifier": "§6Caelestis§7 damage modifier",
+  "simplyswords.weapon_attributes.uniqueDamageModifier.wraithfang_damageModifier": "§6Wraithfang§7 damage modifier",
 
   "simplyswords.weapon_attributes.uniqueAttackSpeed": "§6[Unique Attack Speed Modifiers]",
   "simplyswords.weapon_attributes.uniqueAttackSpeed.desc": "Recommended range: -1.0 to -3.7, with -1.0 being fast and -3.7 being slow.",
@@ -1292,6 +1293,7 @@
   "simplyswords.weapon_attributes.uniqueAttackSpeed.magispear_attackSpeed": "§6Magispear§7 attack speed",
   "simplyswords.weapon_attributes.uniqueAttackSpeed.magiblade_attackSpeed": "§6Magiblade§7 attack speed",
   "simplyswords.weapon_attributes.uniqueAttackSpeed.caelestis_attackSpeed": "§6Caelestis§7 attack speed",
+  "simplyswords.weapon_attributes.uniqueAttackSpeed.wraithfang_attackSpeed": "§6Wraithfang§7 attack speed",
 
   "simplyswords.loot.enableLootDrops": "Enable loot drops",
   "simplyswords.loot.enableLootDrops.desc": "Disabling this setting will prevent Simply Swords from generating loot in chests.",
@@ -1400,12 +1402,12 @@
   "simplyswords.unique_effects.bramblethorn": "§6[Bramblethorn]§7",
   "simplyswords.unique_effects.bramblethorn.Chance": "Bramble chance",
 
-  "simplyswords.unique_effects.soullpyre": "§6[Soulpyre]§7",
-  "simplyswords.unique_effects.soullpyre.duration": "Soultether pulse count",
-  "simplyswords.unique_effects.soullpyre.damage": "Soultether damage",
-  "simplyswords.unique_effects.soullpyre.radius": "Soultether radius",
-  "simplyswords.unique_effects.soullpyre.heal": "Soultether heal",
-  "simplyswords.unique_effects.soullpyre.cooldown": "Soultether cooldown",
+  "simplyswords.unique_effects.soulpyre": "§6[Soulpyre]§7",
+  "simplyswords.unique_effects.soulpyre.duration": "Soultether pulse count",
+  "simplyswords.unique_effects.soulpyre.damage": "Soultether damage",
+  "simplyswords.unique_effects.soulpyre.radius": "Soultether radius",
+  "simplyswords.unique_effects.soulpyre.heal": "Soultether heal",
+  "simplyswords.unique_effects.soulpyre.cooldown": "Soultether cooldown",
 
   "simplyswords.unique_effects.frostfall": "§6[Frostfall]§7",
   "simplyswords.unique_effects.frostfall.chance": "Frost Fury repeat chance",


### PR DESCRIPTION
## #259 - Weapons can spawn with invalid enchantments
Changed the enchanting loot table function to one that does not allow for mace enchantments, or trident enchantments (except for on spears)

## Config files are inconsistently translated
Fixed Wraithfang weapon attribute (damage modifier and attack speed) configs having no translation key.
Fixed soulpyre's translation keys being mistyped as "soullpyre", causing them to not appear in game.
Refactored the field "voidcaller" to "dreadtide" in the unique effect config to adhere to the other field names, and to the translation keys it already had under that prefix.

## ClientAPI can crash when rendering runic tooltips
Changed the `handleRunicSwordTooltip` method to no longer take the `modId` parameter. Instead, it removes the namespace of a runic power via a regex (`[A-Za-z0-9_-]+:`). 
This prevents modded weapons with a modID other than `simplyswords` from crashing if they have a mod-vanilla runic power, and also prevents vanilla runic weapons from crashing if they have an addon runic power. 

# TESTING
All three changes have been tested on Fabric and NeoForge with dependencies, and neither have caused issue.