### PR TITLE
1.21.1 Bug Fixes

### DIFF
--- a/common/src/main/java/net/sweenus/simplyswords/entity/MagispearEntity.java
+++ b/common/src/main/java/net/sweenus/simplyswords/entity/MagispearEntity.java
@@ -5,7 +5,6 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.registry.ItemsRegistry;
@@ -31,19 +30,15 @@ public class MagispearEntity extends ThrownSpearEntity {
 
     @Override
     protected boolean tryPickup(PlayerEntity player) {
-        if (this.isNoClip() && this.isOwner(player)) {
+        boolean canPickup = super.tryPickup(player);
+
+        if (canPickup) {
             int cooldown = Config.uniqueEffects.magispear.cooldown;
             if (offhandThrow) cooldown = Config.uniqueEffects.magispear.cooldown + 4;
             player.getItemCooldownManager().set(this.asItemStack().getItem(), cooldown);
-            if (offhandThrow && player.getOffHandStack().isEmpty()) {
-                // Send the ItemStack to the player's offhand slot if it's free
-                player.setStackInHand(Hand.OFF_HAND, this.asItemStack());
-                return true;
-            } else {
-                return player.getInventory().insertStack(this.asItemStack());
-            }
         }
-        return super.tryPickup(player);
+
+        return canPickup;
     }
 
     @Override

--- a/common/src/main/java/net/sweenus/simplyswords/entity/ThrownSpearEntity.java
+++ b/common/src/main/java/net/sweenus/simplyswords/entity/ThrownSpearEntity.java
@@ -36,7 +36,6 @@ public class ThrownSpearEntity extends PersistentProjectileEntity {
     private static final TrackedData<ItemStack> ITEM_STACK;
     public ItemStack stack;
     public int returnTimer;
-    public PickupPermission pickupType;
     public boolean hasYaw = false;
     private Float initialYaw = null; // Store the initial yaw
     public float keepYaw;
@@ -65,6 +64,11 @@ public class ThrownSpearEntity extends PersistentProjectileEntity {
         this.dataTracker.set(LOYALTY, getLoyalty());
         this.dataTracker.set(ENCHANTED, stack.hasEnchantments());
         this.dataTracker.set(ITEM_STACK, stack);
+
+        this.pickupType = owner.isInCreativeMode() ?
+                PickupPermission.CREATIVE_ONLY :
+                PickupPermission.ALLOWED;
+
         this.stack = stack;
     }
 
@@ -84,11 +88,13 @@ public class ThrownSpearEntity extends PersistentProjectileEntity {
     protected boolean tryPickup(PlayerEntity player) {
         if (!this.isOwner(player)) return false;
 
-
         if (this.isNoClip()) {
             int cooldown = 1;
             if (offhandThrow) cooldown = 4;
             player.getItemCooldownManager().set(this.asItemStack().getItem(), cooldown);
+
+            if (this.pickupType != PickupPermission.ALLOWED) return true;
+
             if (offhandThrow && player.getOffHandStack().isEmpty()) {
                 // Send the ItemStack to the player's offhand slot if it's free
                 player.setStackInHand(Hand.OFF_HAND, this.asItemStack());

--- a/common/src/main/java/net/sweenus/simplyswords/entity/ThrownSpearEntity.java
+++ b/common/src/main/java/net/sweenus/simplyswords/entity/ThrownSpearEntity.java
@@ -82,7 +82,10 @@ public class ThrownSpearEntity extends PersistentProjectileEntity {
     }
 
     protected boolean tryPickup(PlayerEntity player) {
-        if (this.isNoClip() && this.isOwner(player)) {
+        if (!this.isOwner(player)) return false;
+
+
+        if (this.isNoClip()) {
             int cooldown = 1;
             if (offhandThrow) cooldown = 4;
             player.getItemCooldownManager().set(this.asItemStack().getItem(), cooldown);

--- a/common/src/main/java/net/sweenus/simplyswords/entity/ThrownSwordEntity.java
+++ b/common/src/main/java/net/sweenus/simplyswords/entity/ThrownSwordEntity.java
@@ -80,7 +80,9 @@ public class ThrownSwordEntity extends PersistentProjectileEntity {
     }
 
     protected boolean tryPickup(PlayerEntity player) {
-        if (this.isNoClip() && this.isOwner(player)) {
+        if (!this.isOwner(player)) return false;
+
+        if (this.isNoClip()) {
             float cooldown = player.getItemCooldownManager().getCooldownProgress(this.asItemStack().getItem(), 0);
             if (cooldown == 0 && offhandThrow) cooldown = 4;
             player.getItemCooldownManager().set(this.asItemStack().getItem(), (int) cooldown);

--- a/common/src/main/java/net/sweenus/simplyswords/entity/ThrownSwordEntity.java
+++ b/common/src/main/java/net/sweenus/simplyswords/entity/ThrownSwordEntity.java
@@ -37,7 +37,6 @@ public class ThrownSwordEntity extends PersistentProjectileEntity {
     private static final TrackedData<ItemStack> ITEM_STACK;
     public ItemStack stack;
     public int returnTimer;
-    public PickupPermission pickupType;
     public boolean hasYaw = false;
     public float keepYaw;
     public float keepPitch = 0;
@@ -64,6 +63,9 @@ public class ThrownSwordEntity extends PersistentProjectileEntity {
         this.dataTracker.set(ENCHANTED, stack.hasEnchantments());
         this.dataTracker.set(ITEM_STACK, stack);
 
+        this.pickupType = owner.isInCreativeMode() ?
+                PickupPermission.CREATIVE_ONLY :
+                PickupPermission.ALLOWED;
     }
 
     @Override
@@ -86,6 +88,9 @@ public class ThrownSwordEntity extends PersistentProjectileEntity {
             float cooldown = player.getItemCooldownManager().getCooldownProgress(this.asItemStack().getItem(), 0);
             if (cooldown == 0 && offhandThrow) cooldown = 4;
             player.getItemCooldownManager().set(this.asItemStack().getItem(), (int) cooldown);
+
+            if (this.pickupType != PickupPermission.ALLOWED) return true;
+
             if (offhandThrow && player.getOffHandStack().isEmpty()) {
                 // Send the ItemStack to the player's offhand slot if it's free
                 player.setStackInHand(Hand.OFF_HAND, this.asItemStack());

--- a/common/src/main/java/net/sweenus/simplyswords/entity/WraithfangEntity.java
+++ b/common/src/main/java/net/sweenus/simplyswords/entity/WraithfangEntity.java
@@ -9,7 +9,6 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.registry.EffectRegistry;
@@ -50,21 +49,18 @@ public class WraithfangEntity extends ThrownSpearEntity {
 
     @Override
     protected boolean tryPickup(PlayerEntity player) {
-        if (this.isNoClip() && this.isOwner(player)) {
+        boolean canPickup = super.tryPickup(player);
+
+        if (canPickup) {
             player.getWorld().playSound(this, this.getBlockPos(), SoundRegistry.ELEMENTAL_BOW_WIND_SHOOT_IMPACT_02.get(),
                     this.getSoundCategory(), 0.1f, 1.2f);
             player.addStatusEffect(new StatusEffectInstance(StatusEffects.HASTE, Config.uniqueEffects.wraithfang.duration, Config.uniqueEffects.wraithfang.hasteAmplifier, false, false, true));
+
             int cooldown = 10;
             player.getItemCooldownManager().set(this.asItemStack().getItem(), cooldown);
-            if (offhandThrow && player.getOffHandStack().isEmpty()) {
-                // Send the ItemStack to the player's offhand slot if it's free
-                player.setStackInHand(Hand.OFF_HAND, this.asItemStack());
-                return true;
-            } else {
-                return player.getInventory().insertStack(this.asItemStack());
-            }
         }
-        return super.tryPickup(player);
+
+        return canPickup;
     }
 
     @Override

--- a/common/src/main/java/net/sweenus/simplyswords/item/TwoHandedWeapon.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/TwoHandedWeapon.java
@@ -1,4 +1,0 @@
-package net.sweenus.simplyswords.item;
-
-public interface TwoHandedWeapon {
-}

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/ArcanethystSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/ArcanethystSwordItem.java
@@ -22,7 +22,7 @@ import net.sweenus.simplyswords.client.util.TooltipUtils;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
 import net.sweenus.simplyswords.registry.ItemsRegistry;
 import net.sweenus.simplyswords.registry.SoundRegistry;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/BrimstoneClaymoreItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/BrimstoneClaymoreItem.java
@@ -15,7 +15,7 @@ import net.minecraft.world.World;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
 import net.sweenus.simplyswords.registry.ItemsRegistry;
 import net.sweenus.simplyswords.registry.SoundRegistry;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/HearthflameSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/HearthflameSwordItem.java
@@ -23,7 +23,7 @@ import net.sweenus.simplyswords.client.util.TooltipUtils;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
 import net.sweenus.simplyswords.item.component.StoredChargeComponent;
 import net.sweenus.simplyswords.registry.ComponentTypeRegistry;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/IcewhisperSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/IcewhisperSwordItem.java
@@ -23,7 +23,7 @@ import net.sweenus.simplyswords.client.util.TooltipUtils;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
 import net.sweenus.simplyswords.item.component.ChargedLocationComponent;
 import net.sweenus.simplyswords.registry.ComponentTypeRegistry;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/LichbladeSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/LichbladeSwordItem.java
@@ -26,7 +26,7 @@ import net.sweenus.simplyswords.client.util.TooltipUtils;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
 import net.sweenus.simplyswords.item.component.StoredChargeComponent;
 import net.sweenus.simplyswords.item.component.TargetedLocationComponent;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/SoulPyreSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/SoulPyreSwordItem.java
@@ -17,7 +17,7 @@ import net.minecraft.world.World;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
 import net.sweenus.simplyswords.registry.EffectRegistry;
 import net.sweenus.simplyswords.registry.ItemsRegistry;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/SoulkeeperSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/SoulkeeperSwordItem.java
@@ -21,7 +21,7 @@ import net.minecraft.world.World;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
 import net.sweenus.simplyswords.registry.ItemsRegistry;
 import net.sweenus.simplyswords.registry.SoundRegistry;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/SoulrenderSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/SoulrenderSwordItem.java
@@ -24,7 +24,7 @@ import net.sweenus.simplyswords.client.util.TooltipUtils;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
 import net.sweenus.simplyswords.registry.ItemsRegistry;
 import net.sweenus.simplyswords.registry.SoundRegistry;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/ThunderbrandSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/ThunderbrandSwordItem.java
@@ -21,7 +21,7 @@ import net.sweenus.simplyswords.client.util.TooltipUtils;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
 import net.sweenus.simplyswords.registry.ItemsRegistry;
 import net.sweenus.simplyswords.registry.SoundRegistry;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/TwistedBladeItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/TwistedBladeItem.java
@@ -18,7 +18,7 @@ import net.minecraft.world.World;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
 import net.sweenus.simplyswords.registry.ItemsRegistry;
 import net.sweenus.simplyswords.registry.SoundRegistry;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/WatcherClaymoreItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/WatcherClaymoreItem.java
@@ -1,7 +1,7 @@
 package net.sweenus.simplyswords.item.custom;
 
 import net.minecraft.item.ToolMaterial;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 
 public class WatcherClaymoreItem extends WatcherSwordItem  implements TwoHandedWeapon {
 

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/WaxweaverSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/WaxweaverSwordItem.java
@@ -3,12 +3,14 @@ package net.sweenus.simplyswords.item.custom;
 import me.fzzyhmstrs.fzzy_config.validation.number.ValidatedInt;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolMaterial;
 import net.minecraft.item.tooltip.TooltipType;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.registry.tag.DamageTypeTags;
 import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
@@ -17,13 +19,15 @@ import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
+import net.sweenus.simplyswords.item.interfaces.RevivalWeapon;
 import net.sweenus.simplyswords.registry.ItemsRegistry;
+import net.sweenus.simplyswords.registry.SoundRegistry;
 import net.sweenus.simplyswords.util.HelperMethods;
 import net.sweenus.simplyswords.util.Styles;
 
 import java.util.List;
 
-public class WaxweaverSwordItem extends UniqueSwordItem {
+public class WaxweaverSwordItem extends UniqueSwordItem implements RevivalWeapon {
     public WaxweaverSwordItem(ToolMaterial toolMaterial, Settings settings) {
         super(toolMaterial, settings);
     }
@@ -41,6 +45,30 @@ public class WaxweaverSwordItem extends UniqueSwordItem {
 
         }
         return super.postHit(stack, target, attacker);
+    }
+
+    @Override
+    public boolean canRevive(PlayerEntity player, ItemStack stack, DamageSource source) {
+        return !source.isIn(DamageTypeTags.BYPASSES_INVULNERABILITY) &&
+                !player.getItemCooldownManager().isCoolingDown(this);
+    }
+
+    @Override
+    public void postRevive(PlayerEntity player, ItemStack stack, DamageSource source) {
+        int skillCooldown = Config.uniqueEffects.waxweaver.cooldown;
+        HelperMethods.incrementStatusEffect(player, StatusEffects.RESISTANCE, 100, 2, 3);
+        player.getItemCooldownManager().set(stack.getItem(), skillCooldown);
+
+        World world = player.getWorld();
+        world.playSound(null, player.getBlockPos(), SoundRegistry.MAGIC_SWORD_SPELL_02.get(),
+                player.getSoundCategory(), 0.7f, 1.0f);
+        world.playSound(null, player.getBlockPos(), SoundRegistry.SPELL_MISC_02.get(),
+                player.getSoundCategory(), 0.8f, 1.0f);
+    }
+
+    @Override
+    public float getReviveHealth(PlayerEntity player, ItemStack stack, DamageSource source) {
+        return player.getMaxHealth();
     }
 
     @Override

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/WhisperwindSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/WhisperwindSwordItem.java
@@ -18,7 +18,7 @@ import net.minecraft.world.World;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
 import net.sweenus.simplyswords.registry.EffectRegistry;
 import net.sweenus.simplyswords.registry.ItemsRegistry;

--- a/common/src/main/java/net/sweenus/simplyswords/item/custom/WickpiercerSwordItem.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/custom/WickpiercerSwordItem.java
@@ -5,11 +5,13 @@ import me.fzzyhmstrs.fzzy_config.validation.number.ValidatedInt;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolMaterial;
 import net.minecraft.item.tooltip.TooltipType;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.registry.tag.DamageTypeTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
@@ -20,6 +22,7 @@ import net.sweenus.simplyswords.config.settings.ItemStackTooltipAppender;
 import net.sweenus.simplyswords.config.settings.TooltipSettings;
 import net.sweenus.simplyswords.entity.WickpiercerEntity;
 import net.sweenus.simplyswords.item.UniqueSwordItem;
+import net.sweenus.simplyswords.item.interfaces.RevivalWeapon;
 import net.sweenus.simplyswords.registry.EffectRegistry;
 import net.sweenus.simplyswords.registry.ItemsRegistry;
 import net.sweenus.simplyswords.registry.SoundRegistry;
@@ -28,7 +31,7 @@ import net.sweenus.simplyswords.util.Styles;
 
 import java.util.List;
 
-public class WickpiercerSwordItem extends UniqueSwordItem {
+public class WickpiercerSwordItem extends UniqueSwordItem implements RevivalWeapon {
     public WickpiercerSwordItem(ToolMaterial toolMaterial, Settings settings) {
         super(toolMaterial, settings);
     }
@@ -119,6 +122,30 @@ public class WickpiercerSwordItem extends UniqueSwordItem {
         tooltip.add(Text.translatable("item.simplyswords.wickpiercersworditem.tooltip7").setStyle(Styles.TEXT));
 
         super.appendTooltip(itemStack, tooltipContext, tooltip, type);
+    }
+
+    @Override
+    public boolean canRevive(PlayerEntity player, ItemStack stack, DamageSource source) {
+        return !source.isIn(DamageTypeTags.BYPASSES_INVULNERABILITY) &&
+                !player.getItemCooldownManager().isCoolingDown(this);
+    }
+
+    @Override
+    public void postRevive(PlayerEntity player, ItemStack stack, DamageSource source) {
+        int skillCooldown = Config.uniqueEffects.waxweaver.cooldown;
+        HelperMethods.incrementStatusEffect(player, StatusEffects.RESISTANCE, 100, 2, 3);
+        player.getItemCooldownManager().set(stack.getItem(), skillCooldown);
+
+        World world = player.getWorld();
+        world.playSound(null, player.getBlockPos(), SoundRegistry.MAGIC_SWORD_SPELL_02.get(),
+                player.getSoundCategory(), 0.7f, 1.0f);
+        world.playSound(null, player.getBlockPos(), SoundRegistry.SPELL_MISC_02.get(),
+                player.getSoundCategory(), 0.8f, 1.0f);
+    }
+
+    @Override
+    public float getReviveHealth(PlayerEntity player, ItemStack stack, DamageSource source) {
+        return player.getMaxHealth();
     }
 
     public static class EffectSettings extends TooltipSettings {

--- a/common/src/main/java/net/sweenus/simplyswords/item/interfaces/RevivalWeapon.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/interfaces/RevivalWeapon.java
@@ -1,0 +1,13 @@
+package net.sweenus.simplyswords.item.interfaces;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public interface RevivalWeapon {
+    boolean canRevive(PlayerEntity entity, ItemStack stack, DamageSource source);
+    void postRevive(PlayerEntity entity, ItemStack stack, DamageSource source);
+    float getReviveHealth(PlayerEntity entity, ItemStack stack, DamageSource source);
+}

--- a/common/src/main/java/net/sweenus/simplyswords/item/interfaces/TwoHandedWeapon.java
+++ b/common/src/main/java/net/sweenus/simplyswords/item/interfaces/TwoHandedWeapon.java
@@ -1,0 +1,4 @@
+package net.sweenus.simplyswords.item.interfaces;
+
+public interface TwoHandedWeapon {
+}

--- a/common/src/main/java/net/sweenus/simplyswords/mixin/LivingEntityMixin.java
+++ b/common/src/main/java/net/sweenus/simplyswords/mixin/LivingEntityMixin.java
@@ -33,8 +33,6 @@ import static net.sweenus.simplyswords.SimplySwords.minimumEldritchEndVersion;
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin {
 
-    @Shadow public abstract void setHealth(float health);
-
     @Inject(at = @At("HEAD"), method = "tryUseTotem", cancellable = true)
     public void simplyswords$tryRevive(DamageSource source, CallbackInfoReturnable<Boolean> cir) {
         LivingEntity livingEntity = (LivingEntity) (Object) this;
@@ -42,7 +40,7 @@ public abstract class LivingEntityMixin {
             ItemStack mainhand = player.getStackInHand(Hand.MAIN_HAND);
             if (mainhand.getItem() instanceof RevivalWeapon revivalWeapon) {
                 if(revivalWeapon.canRevive(player, mainhand, source)) {
-                    setHealth(revivalWeapon.getReviveHealth(player, mainhand, source));
+                    player.setHealth(revivalWeapon.getReviveHealth(player, mainhand, source));
                     revivalWeapon.postRevive(player, mainhand, source);
                     cir.setReturnValue(true);
                 }

--- a/common/src/main/java/net/sweenus/simplyswords/mixin/LivingEntityMixin.java
+++ b/common/src/main/java/net/sweenus/simplyswords/mixin/LivingEntityMixin.java
@@ -8,16 +8,20 @@ import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
+import net.minecraft.registry.tag.DamageTypeTags;
+import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.World;
 import net.sweenus.simplyswords.SimplySwords;
 import net.sweenus.simplyswords.compat.eldritch_end.EldritchEndCompatMethods;
 import net.sweenus.simplyswords.config.Config;
+import net.sweenus.simplyswords.item.interfaces.RevivalWeapon;
 import net.sweenus.simplyswords.registry.EffectRegistry;
 import net.sweenus.simplyswords.registry.ItemsRegistry;
 import net.sweenus.simplyswords.registry.SoundRegistry;
 import net.sweenus.simplyswords.util.HelperMethods;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
@@ -29,27 +33,18 @@ import static net.sweenus.simplyswords.SimplySwords.minimumEldritchEndVersion;
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin {
 
-    @Inject(at = @At("HEAD"), method = "isDead", cancellable = true)
-    public void simplyswords$tick(CallbackInfoReturnable<Boolean> cir) {
+    @Shadow public abstract void setHealth(float health);
+
+    @Inject(at = @At("HEAD"), method = "tryUseTotem", cancellable = true)
+    public void simplyswords$tryRevive(DamageSource source, CallbackInfoReturnable<Boolean> cir) {
         LivingEntity livingEntity = (LivingEntity) (Object) this;
-        if (!livingEntity.getWorld().isClient()) {
-            if (livingEntity instanceof PlayerEntity player) {
-                World world = player.getWorld();
-                ItemStack stack = player.getMainHandStack();
-
-                if (player.getHealth() <= 0.0F && !player.getItemCooldownManager().isCoolingDown(stack.getItem())
-                        && (stack.isOf(ItemsRegistry.WAXWEAVER.get())
-                        || stack.isOf(ItemsRegistry.WICKPIERCER.get()))) {
-
-                    int skillCooldown = Config.uniqueEffects.waxweaver.cooldown;
-                    player.setHealth(player.getMaxHealth());
-                    HelperMethods.incrementStatusEffect(player, StatusEffects.RESISTANCE, 100, 2, 3);
-                    player.getItemCooldownManager().set(stack.getItem(), skillCooldown);
-                    world.playSound(null, player.getBlockPos(), SoundRegistry.MAGIC_SWORD_SPELL_02.get(),
-                            player.getSoundCategory(), 0.7f, 1.0f);
-                    world.playSound(null, player.getBlockPos(), SoundRegistry.SPELL_MISC_02.get(),
-                            player.getSoundCategory(), 0.8f, 1.0f);
-                    cir.setReturnValue(false);
+        if(livingEntity instanceof PlayerEntity player && !player.getWorld().isClient()) {
+            ItemStack mainhand = player.getStackInHand(Hand.MAIN_HAND);
+            if (mainhand.getItem() instanceof RevivalWeapon revivalWeapon) {
+                if(revivalWeapon.canRevive(player, mainhand, source)) {
+                    setHealth(revivalWeapon.getReviveHealth(player, mainhand, source));
+                    revivalWeapon.postRevive(player, mainhand, source);
+                    cir.setReturnValue(true);
                 }
             }
         }

--- a/common/src/main/java/net/sweenus/simplyswords/util/HelperMethods.java
+++ b/common/src/main/java/net/sweenus/simplyswords/util/HelperMethods.java
@@ -42,7 +42,7 @@ import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.effect.instance.SimplySwordsStatusEffectInstance;
 import net.sweenus.simplyswords.entity.BattleStandardDarkEntity;
 import net.sweenus.simplyswords.entity.BattleStandardEntity;
-import net.sweenus.simplyswords.item.TwoHandedWeapon;
+import net.sweenus.simplyswords.item.interfaces.TwoHandedWeapon;
 import net.sweenus.simplyswords.registry.ParticlesRegistry;
 import net.sweenus.simplyswords.registry.SoundRegistry;
 

--- a/common/src/main/resources/assets/simplyswords/models/item/stars_edge.json
+++ b/common/src/main/resources/assets/simplyswords/models/item/stars_edge.json
@@ -1,7 +1,7 @@
 {
 	"parent": "simplyswords:item/template_twinblade",
 	"textures": {
-		"layer0": "simplyswords:item/storms_edge",
+		"layer0": "simplyswords:item/stars_edge",
 		"layer1": "simplyswords:item/stars_edge_anim_03",
 		"layer2": "simplyswords:item/stars_edge_anim_01"
 	}


### PR DESCRIPTION
# Changes
## #303 - Throwable weapons can be picked up by other people.
The `#tryPickup()` method  on `ThrownSpearEntity` and `ThrownSwordEntity` checks whether the player picking up the weapon is the owner, but then delegates to super (PersistentProjectileEntity#tryPickup()) - which does not. Instead, this now returns false early if the player is not the owner.

## #299 - [Throwable weapons]... duplicate in creative mode.
This issue is more a suggestion to make spear uniques not throwable, but they do report the issue that throwable items duplicate in creative mode. `PersistentProjectileEntity#pickupType` is now set in the constructor of `ThrownSwordEntity` and `ThrownSpearEntity` to make it work similarly to other projectiles, such as tridents and arrows. Removed `#pickupType` from `ThrownSwordEntity` and `ThrownSpearEntity` as `PersistentProjectileEntity#pickupType` is public, and rewrote some overridden methods to work with these changes.

## #300 - Revival uniques prevent /kill.
Waxweaver and Wickpiercer were not checking that the damage source that caused death should go through invulnerability (which includes totems and other revive effects). Revive logic has been moved into the `LivingEntity#tryUseTotem()` method, instead of `LivingEntity#isDead()`, to allow for this check. This also means that the uniques now trigger before totems, instead of the other way around, which is probably better for QoL.

I abstracted the revival logic behind an interface, so that it's easier for me to use for a planned SimplyMore unique.

## #285 - Star's Edge uses Storm's Edge base texture.
Despite having its own texture, Star's Edge uses the Storm's Edge base texture, so I've swapped this over. Obviously it makes the weapon look different, so if this was intentional, cherry pick this commit out.

# Testing
Fabric tested within DevEnv and a play instance, using multiple clients on a LAN server where applicable. No issues found.
NeoForge tested only within a play instance. No issues found, though I was not able to test #303.

# Notes
While out of scope for this PR, I feel like throwable weapons should trigger enchants on hit - as they physically make contact with the target (this was our decision for Mimi-cry, where the right click(s) are martial.). 

The changes to throwable weapons are exactly in line with the trident's behaviour. 

All but the Star's Edge change are made in preparation for a SimplyMore update, adding two throwing uniques, a revival unique, and a unique that prevents revives.

I have not version bumped.